### PR TITLE
Phase 0: add tokens, IR node/schema, and component registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,5 +36,8 @@ target-version = ['py313']
 profile = "black"
 line_length = 88
 
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/paperops"]

--- a/src/paperops/slides/components/registry.py
+++ b/src/paperops/slides/components/registry.py
@@ -1,0 +1,87 @@
+"""Component registry and declaration helper decorators."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+
+@dataclass(frozen=True)
+class ComponentDefinition:
+    """Metadata describing one registered component."""
+
+    type: str
+    props_schema: dict[str, Any] = field(default_factory=dict)
+    default_classes: list[str] = field(default_factory=list)
+    expand: Callable[[dict[str, Any]], Any] | None = None
+
+
+class ComponentRegistry:
+    """Simple, strict component registry."""
+
+    def __init__(self) -> None:
+        self._definitions: dict[str, ComponentDefinition] = {}
+
+    def register(
+        self, component_type: str, definition: ComponentDefinition
+    ) -> ComponentDefinition:
+        if component_type in self._definitions:
+            raise ValueError(f"Component '{component_type}' already registered")
+        self._definitions[component_type] = definition
+        return definition
+
+    def get(self, component_type: str) -> ComponentDefinition:
+        return self._definitions[component_type]
+
+    def has(self, component_type: str) -> bool:
+        return component_type in self._definitions
+
+    def as_dict(self) -> dict[str, ComponentDefinition]:
+        return dict(self._definitions)
+
+
+def register_component(
+    type_name: str,
+    *,
+    props_schema: dict[str, Any] | None = None,
+    default_classes: list[str] | None = None,
+    expand: Callable[[dict[str, Any]], Any] | None = None,
+):
+    """Decorator to register components.
+
+    Usage:
+        @register_component("kpi", props_schema={"value": {"type": "number"}})
+        class Kpi: ...
+    """
+
+    if not type_name or not isinstance(type_name, str):
+        raise TypeError("type_name must be a non-empty string")
+
+    def decorator(target: Any):
+        target_schema = props_schema
+        if target_schema is None:
+            target_schema = getattr(target, "props_schema", {})
+        target_classes = (
+            default_classes
+            if default_classes is not None
+            else list(getattr(target, "default_classes", []))
+        )
+        target_expand = (
+            expand if expand is not None else getattr(target, "expand", None)
+        )
+
+        definition = ComponentDefinition(
+            type=type_name,
+            props_schema=target_schema or {},
+            default_classes=target_classes or [],
+            expand=target_expand,
+        )
+        registry.register(type_name, definition)
+        return target
+
+    return decorator
+
+
+registry = ComponentRegistry()
+
+__all__ = ["ComponentDefinition", "ComponentRegistry", "register_component", "registry"]

--- a/src/paperops/slides/core/__init__.py
+++ b/src/paperops/slides/core/__init__.py
@@ -1,5 +1,26 @@
 """Core layer: theme, types, constants."""
 
 from paperops.slides.core.theme import Theme, themes
+from paperops.slides.core.tokens import (
+    UnknownTokenCategoryError,
+    UnknownTokenError,
+    resolve,
+    resolve_token,
+)
 from paperops.slides.core.types import resolve_color, resolve_font_size, resolve_size
 from paperops.slides.core.constants import SLIDE_WIDTH, SLIDE_HEIGHT, CONTENT_REGION
+
+__all__ = [
+    "UnknownTokenCategoryError",
+    "UnknownTokenError",
+    "Theme",
+    "themes",
+    "CONTENT_REGION",
+    "SLIDE_HEIGHT",
+    "SLIDE_WIDTH",
+    "resolve",
+    "resolve_color",
+    "resolve_font_size",
+    "resolve_size",
+    "resolve_token",
+]

--- a/src/paperops/slides/core/theme.py
+++ b/src/paperops/slides/core/theme.py
@@ -1,88 +1,171 @@
-"""Theme system — single source of truth for all visual properties."""
+"""Token-based theme definitions for paperops.slides."""
 
 from __future__ import annotations
+
 from dataclasses import dataclass, field
-import functools
 from copy import deepcopy
+import functools
+import re
+from typing import Any
+
+from paperops.slides.core.tokens import (
+    ShadowSpec,
+    UnknownTokenCategoryError,
+    UnknownTokenError,
+    resolve_token as _resolve_token,
+)
+
+
+def _validate_hex(value: str) -> str:
+    if not isinstance(value, str) or not value.startswith("#") or len(value) != 7:
+        raise ValueError(f"Invalid hex color: {value!r}")
+    if not re.fullmatch(r"#[0-9a-fA-F]{6}", value):
+        raise ValueError(f"Invalid hex color: {value!r}")
+    return value
+
+
+def _validate_required_tokens(
+    theme_name: str, label: str, required: set[str], values: dict[str, Any]
+) -> None:
+    missing = required - set(values.keys())
+    if missing:
+        raise ValueError(
+            f"Theme '{theme_name}' missing required {label}: {sorted(missing)}"
+        )
 
 
 _REQUIRED_COLORS = {
-    "primary", "secondary", "accent",
-    "positive", "negative", "highlight", "warning",
-    "text", "text_mid", "text_light",
-    "bg", "bg_alt", "bg_accent", "border",
+    "primary",
+    "secondary",
+    "accent",
+    "positive",
+    "negative",
+    "highlight",
+    "warning",
+    "text",
+    "text_mid",
+    "text_light",
+    "bg",
+    "bg_alt",
+    "bg_accent",
+    "border",
 }
 
 _REQUIRED_FONTS = {"title", "subtitle", "heading", "body", "caption", "small"}
+_REQUIRED_SPACING = {"xs", "sm", "md", "lg", "xl", "2xl"}
+_REQUIRED_RADIUS = {"none", "sm", "md", "lg", "full"}
+_REQUIRED_SHADOW = {"sm", "md", "lg"}
+_REQUIRED_DURATION = {"instant", "fast", "base", "slow"}
+_ALLOWED_DENSITY = {"compact", "normal", "airy"}
 
 
 @dataclass
 class Theme:
+    """Theme token container."""
+
     name: str
     colors: dict[str, str] = field(default_factory=dict)
-    fonts: dict[str, float] = field(default_factory=dict)  # name → point size
+    fonts: dict[str, float] = field(default_factory=dict)
     font_family: str = "Calibri"
     font_mono: str = "Consolas"
+    spacing: dict[str, float] = field(default_factory=dict)
+    radius: dict[str, float] = field(default_factory=dict)
+    shadow: dict[str, ShadowSpec] = field(default_factory=dict)
+    duration: dict[str, float] = field(default_factory=dict)
+    density: str = "normal"
+    baseline: float = 0.1
 
     def __post_init__(self):
-        missing_colors = _REQUIRED_COLORS - set(self.colors.keys())
-        if missing_colors:
-            raise ValueError(f"Theme '{self.name}' missing required colors: {missing_colors}")
-        missing_fonts = _REQUIRED_FONTS - set(self.fonts.keys())
-        if missing_fonts:
-            raise ValueError(f"Theme '{self.name}' missing required font sizes: {missing_fonts}")
+        _validate_required_tokens(self.name, "colors", _REQUIRED_COLORS, self.colors)
+        _validate_required_tokens(self.name, "font scales", _REQUIRED_FONTS, self.fonts)
+        _validate_required_tokens(self.name, "spacing", _REQUIRED_SPACING, self.spacing)
+        _validate_required_tokens(self.name, "radius", _REQUIRED_RADIUS, self.radius)
+        _validate_required_tokens(self.name, "shadow", _REQUIRED_SHADOW, self.shadow)
+        _validate_required_tokens(
+            self.name, "duration", _REQUIRED_DURATION, self.duration
+        )
 
-    def override(self, **kwargs) -> Theme:
-        """Create a new theme with selective overrides.
+        if self.density not in _ALLOWED_DENSITY:
+            raise ValueError(
+                f"Theme '{self.name}' has invalid density '{self.density}'. "
+                f"Must be one of {_ALLOWED_DENSITY}"
+            )
+        if self.baseline <= 0:
+            raise ValueError(f"Theme '{self.name}' baseline must be positive")
 
-        Accepts: name, colors (merged), fonts (merged), font_family, font_mono.
-        """
+        for key in _REQUIRED_COLORS:
+            self.colors[key] = _validate_hex(self.colors[key])
+
+        for key in _REQUIRED_FONTS:
+            self.fonts[key] = float(self.fonts[key])
+
+        for key in _REQUIRED_SPACING:
+            self.spacing[key] = float(self.spacing[key])
+
+        for key in _REQUIRED_RADIUS:
+            self.radius[key] = float(self.radius[key])
+
+        for key in _REQUIRED_DURATION:
+            self.duration[key] = float(self.duration[key])
+
+        for key in _REQUIRED_SHADOW:
+            spec = self.shadow[key]
+            if isinstance(spec, dict):
+                self.shadow[key] = ShadowSpec(
+                    float(spec["dx"]),
+                    float(spec["dy"]),
+                    float(spec["blur"]),
+                    _validate_hex(spec["color"]),
+                    float(spec.get("opacity", 1.0)),
+                )
+            elif not isinstance(spec, ShadowSpec):
+                raise TypeError(
+                    f"Theme '{self.name}' shadow '{key}' must be ShadowSpec or dict, got {type(spec)!r}"
+                )
+
+        try:
+            self.resolve_token("spacing", "md")
+            self.resolve_token("colors", "primary")
+        except (UnknownTokenError, UnknownTokenCategoryError):
+            # Keep error message stable and fail fast at construction time.
+            raise
+
+    def override(self, **kwargs) -> "Theme":
+        """Create a new theme from `self`, applying shallow token overrides."""
         new = deepcopy(self)
         for key, value in kwargs.items():
-            if key == "colors":
-                new.colors.update(value)
-            elif key == "fonts":
-                new.fonts.update(value)
-            elif hasattr(new, key):
+            if key in {"colors", "fonts", "spacing", "radius", "shadow", "duration"}:
+                current = getattr(new, key)
+                current.update(value)
+                setattr(new, key, current)
+            elif key == "font_family" or key == "font_mono" or key == "density":
                 setattr(new, key, value)
+            elif key == "baseline":
+                new.baseline = float(value)
+            elif key == "name":
+                new.name = value
             else:
                 raise ValueError(f"Unknown theme attribute: {key}")
         new.__post_init__()
         return new
 
-    def resolve_color(self, color) -> str:
-        """Resolve a color value to hex string.
+    def resolve_token(self, category: str, value):
+        """Resolve a token for this theme through the unified token parser."""
+        return _resolve_token(self, category, value)
 
-        Accepts:
-          - str semantic name ("primary") → lookup in theme
-          - str hex ("#3B6B9D") → pass through
-          - tuple (r, g, b) → convert to hex
-        """
-        if isinstance(color, tuple):
-            r, g, b = color
-            return f"#{r:02X}{g:02X}{b:02X}"
-        if isinstance(color, str):
-            if color.startswith("#"):
-                return color
-            if color in self.colors:
-                return self.colors[color]
-            raise ValueError(f"Unknown color name: '{color}'. Available: {sorted(self.colors.keys())}")
-        raise TypeError(f"Invalid color type: {type(color)}")
+    def resolve_color(self, color) -> str:
+        """Backward-compatible color resolver used by existing code."""
+        return self.resolve_token("colors", color)
 
     def resolve_font_size(self, size) -> float:
-        """Resolve a font size to points (float).
+        """Backward-compatible font-size resolver used by existing code."""
+        resolved = self.resolve_token("fonts", size)
+        if isinstance(resolved, str):
+            return float(resolved)
+        return float(resolved)
 
-        Accepts:
-          - str semantic name ("body") → lookup in theme
-          - int/float → use directly as pt
-        """
-        if isinstance(size, str):
-            if size in self.fonts:
-                return self.fonts[size]
-            raise ValueError(f"Unknown font size name: '{size}'. Available: {sorted(self.fonts.keys())}")
-        if isinstance(size, (int, float)):
-            return float(size)
-        raise TypeError(f"Invalid font size type: {type(size)}")
+    def resolve_shadow(self, key: str) -> ShadowSpec:
+        return self.resolve_token("shadow", key)
 
 
 class _Themes:
@@ -93,20 +176,20 @@ class _Themes:
         return Theme(
             name="executive",
             colors={
-                "primary":    "#16324F",
-                "secondary":  "#356B6F",
-                "accent":     "#C8792A",
-                "positive":   "#2E6B57",
-                "negative":   "#B44D3E",
-                "highlight":  "#4768A8",
-                "warning":    "#B6923E",
-                "text":       "#16212B",
-                "text_mid":   "#51606F",
+                "primary": "#16324F",
+                "secondary": "#356B6F",
+                "accent": "#C8792A",
+                "positive": "#2E6B57",
+                "negative": "#B44D3E",
+                "highlight": "#4768A8",
+                "warning": "#B6923E",
+                "text": "#16212B",
+                "text_mid": "#51606F",
                 "text_light": "#7C8A98",
-                "bg":         "#F7F6F2",
-                "bg_alt":     "#ECEAE3",
-                "bg_accent":  "#E2E8EE",
-                "border":     "#C5CBD3",
+                "bg": "#F7F6F2",
+                "bg_alt": "#ECEAE3",
+                "bg_accent": "#E2E8EE",
+                "border": "#C5CBD3",
             },
             fonts={
                 "title": 30,
@@ -118,6 +201,52 @@ class _Themes:
             },
             font_family="Liberation Sans",
             font_mono="Liberation Mono",
+            spacing={
+                "xs": 0.08,
+                "sm": 0.16,
+                "md": 0.32,
+                "lg": 0.64,
+                "xl": 1.0,
+                "2xl": 1.6,
+            },
+            radius={
+                "none": 0.0,
+                "sm": 0.05,
+                "md": 0.12,
+                "lg": 0.24,
+                "full": 99.0,
+            },
+            shadow={
+                "sm": {
+                    "dx": 0.02,
+                    "dy": 0.02,
+                    "blur": 0.08,
+                    "color": "#C5CBD3",
+                    "opacity": 0.35,
+                },
+                "md": {
+                    "dx": 0.04,
+                    "dy": 0.04,
+                    "blur": 0.15,
+                    "color": "#C5CBD3",
+                    "opacity": 0.40,
+                },
+                "lg": {
+                    "dx": 0.06,
+                    "dy": 0.06,
+                    "blur": 0.35,
+                    "color": "#C5CBD3",
+                    "opacity": 0.45,
+                },
+            },
+            duration={
+                "instant": 0.0,
+                "fast": 0.2,
+                "base": 0.4,
+                "slow": 0.8,
+            },
+            density="normal",
+            baseline=0.1,
         )
 
     @functools.cached_property
@@ -125,20 +254,20 @@ class _Themes:
         return Theme(
             name="academic_seminar",
             colors={
-                "primary":    "#1F3A5F",
-                "secondary":  "#4B627D",
-                "accent":     "#C47A2C",
-                "positive":   "#2F6B57",
-                "negative":   "#B34E48",
-                "highlight":  "#3F5F90",
-                "warning":    "#A8842C",
-                "text":       "#18232F",
-                "text_mid":   "#546170",
+                "primary": "#1F3A5F",
+                "secondary": "#4B627D",
+                "accent": "#C47A2C",
+                "positive": "#2F6B57",
+                "negative": "#B34E48",
+                "highlight": "#3F5F90",
+                "warning": "#A8842C",
+                "text": "#18232F",
+                "text_mid": "#546170",
                 "text_light": "#7F8A96",
-                "bg":         "#FFFFFF",
-                "bg_alt":     "#F4F6F8",
-                "bg_accent":  "#EAF0F5",
-                "border":     "#D2D8DF",
+                "bg": "#FFFFFF",
+                "bg_alt": "#F4F6F8",
+                "bg_accent": "#EAF0F5",
+                "border": "#D2D8DF",
             },
             fonts={
                 "title": 26,
@@ -150,6 +279,52 @@ class _Themes:
             },
             font_family="Liberation Sans",
             font_mono="Liberation Mono",
+            spacing={
+                "xs": 0.09,
+                "sm": 0.18,
+                "md": 0.36,
+                "lg": 0.72,
+                "xl": 1.2,
+                "2xl": 1.9,
+            },
+            radius={
+                "none": 0.0,
+                "sm": 0.06,
+                "md": 0.16,
+                "lg": 0.28,
+                "full": 99.0,
+            },
+            shadow={
+                "sm": {
+                    "dx": 0.02,
+                    "dy": 0.02,
+                    "blur": 0.10,
+                    "color": "#D2D8DF",
+                    "opacity": 0.30,
+                },
+                "md": {
+                    "dx": 0.05,
+                    "dy": 0.05,
+                    "blur": 0.16,
+                    "color": "#D2D8DF",
+                    "opacity": 0.40,
+                },
+                "lg": {
+                    "dx": 0.08,
+                    "dy": 0.08,
+                    "blur": 0.34,
+                    "color": "#D2D8DF",
+                    "opacity": 0.50,
+                },
+            },
+            duration={
+                "instant": 0.0,
+                "fast": 0.2,
+                "base": 0.5,
+                "slow": 0.9,
+            },
+            density="compact",
+            baseline=0.1,
         )
 
     @functools.cached_property
@@ -157,27 +332,77 @@ class _Themes:
         return Theme(
             name="professional",
             colors={
-                "primary":    "#3B6B9D",
-                "secondary":  "#4A8B7F",
-                "accent":     "#C27C3E",
-                "positive":   "#4A7C5F",
-                "negative":   "#B85450",
-                "highlight":  "#6B5B8D",
-                "warning":    "#C4A34D",
-                "text":       "#1E293B",
-                "text_mid":   "#64748B",
+                "primary": "#3B6B9D",
+                "secondary": "#4A8B7F",
+                "accent": "#C27C3E",
+                "positive": "#4A7C5F",
+                "negative": "#B85450",
+                "highlight": "#6B5B8D",
+                "warning": "#C4A34D",
+                "text": "#1E293B",
+                "text_mid": "#64748B",
                 "text_light": "#94A3B8",
-                "bg":         "#FFFFFF",
-                "bg_alt":     "#F7F8FA",
-                "bg_accent":  "#EEF0F5",
-                "border":     "#C8CED8",
+                "bg": "#FFFFFF",
+                "bg_alt": "#F7F8FA",
+                "bg_accent": "#EEF0F5",
+                "border": "#C8CED8",
             },
             fonts={
-                "title": 32, "subtitle": 24, "heading": 20,
-                "body": 18, "caption": 14, "small": 11,
+                "title": 32,
+                "subtitle": 24,
+                "heading": 20,
+                "body": 18,
+                "caption": 14,
+                "small": 11,
             },
             font_family="Calibri",
             font_mono="Consolas",
+            spacing={
+                "xs": 0.08,
+                "sm": 0.15,
+                "md": 0.30,
+                "lg": 0.60,
+                "xl": 0.96,
+                "2xl": 1.55,
+            },
+            radius={
+                "none": 0.0,
+                "sm": 0.04,
+                "md": 0.10,
+                "lg": 0.18,
+                "full": 99.0,
+            },
+            shadow={
+                "sm": {
+                    "dx": 0.02,
+                    "dy": 0.02,
+                    "blur": 0.07,
+                    "color": "#C8CED8",
+                    "opacity": 0.25,
+                },
+                "md": {
+                    "dx": 0.04,
+                    "dy": 0.04,
+                    "blur": 0.14,
+                    "color": "#C8CED8",
+                    "opacity": 0.35,
+                },
+                "lg": {
+                    "dx": 0.07,
+                    "dy": 0.07,
+                    "blur": 0.30,
+                    "color": "#C8CED8",
+                    "opacity": 0.42,
+                },
+            },
+            duration={
+                "instant": 0.0,
+                "fast": 0.15,
+                "base": 0.35,
+                "slow": 0.75,
+            },
+            density="normal",
+            baseline=0.09,
         )
 
     @functools.cached_property
@@ -185,27 +410,77 @@ class _Themes:
         return Theme(
             name="minimal",
             colors={
-                "primary":    "#2D3748",
-                "secondary":  "#4A5568",
-                "accent":     "#3182CE",
-                "positive":   "#38A169",
-                "negative":   "#E53E3E",
-                "highlight":  "#805AD5",
-                "warning":    "#D69E2E",
-                "text":       "#1A202C",
-                "text_mid":   "#718096",
+                "primary": "#2D3748",
+                "secondary": "#4A5568",
+                "accent": "#3182CE",
+                "positive": "#38A169",
+                "negative": "#E53E3E",
+                "highlight": "#805AD5",
+                "warning": "#D69E2E",
+                "text": "#1A202C",
+                "text_mid": "#718096",
                 "text_light": "#A0AEC0",
-                "bg":         "#FFFFFF",
-                "bg_alt":     "#F7FAFC",
-                "bg_accent":  "#EDF2F7",
-                "border":     "#E2E8F0",
+                "bg": "#FFFFFF",
+                "bg_alt": "#F7FAFC",
+                "bg_accent": "#EDF2F7",
+                "border": "#E2E8F0",
             },
             fonts={
-                "title": 32, "subtitle": 24, "heading": 20,
-                "body": 18, "caption": 14, "small": 11,
+                "title": 32,
+                "subtitle": 24,
+                "heading": 20,
+                "body": 18,
+                "caption": 14,
+                "small": 11,
             },
             font_family="Calibri",
             font_mono="Consolas",
+            spacing={
+                "xs": 0.07,
+                "sm": 0.14,
+                "md": 0.28,
+                "lg": 0.56,
+                "xl": 0.86,
+                "2xl": 1.45,
+            },
+            radius={
+                "none": 0.0,
+                "sm": 0.03,
+                "md": 0.08,
+                "lg": 0.16,
+                "full": 99.0,
+            },
+            shadow={
+                "sm": {
+                    "dx": 0.02,
+                    "dy": 0.02,
+                    "blur": 0.06,
+                    "color": "#E2E8F0",
+                    "opacity": 0.20,
+                },
+                "md": {
+                    "dx": 0.04,
+                    "dy": 0.04,
+                    "blur": 0.12,
+                    "color": "#E2E8F0",
+                    "opacity": 0.25,
+                },
+                "lg": {
+                    "dx": 0.06,
+                    "dy": 0.06,
+                    "blur": 0.24,
+                    "color": "#E2E8F0",
+                    "opacity": 0.3,
+                },
+            },
+            duration={
+                "instant": 0.0,
+                "fast": 0.2,
+                "base": 0.4,
+                "slow": 0.8,
+            },
+            density="airy",
+            baseline=0.1,
         )
 
     @functools.cached_property
@@ -213,27 +488,77 @@ class _Themes:
         return Theme(
             name="academic",
             colors={
-                "primary":    "#8B4513",
-                "secondary":  "#2E6B4F",
-                "accent":     "#4A6FA5",
-                "positive":   "#2E6B4F",
-                "negative":   "#A0522D",
-                "highlight":  "#6B4C8D",
-                "warning":    "#B8860B",
-                "text":       "#2C2C2C",
-                "text_mid":   "#5A5A5A",
+                "primary": "#8B4513",
+                "secondary": "#2E6B4F",
+                "accent": "#4A6FA5",
+                "positive": "#2E6B4F",
+                "negative": "#A0522D",
+                "highlight": "#6B4C8D",
+                "warning": "#B8860B",
+                "text": "#2C2C2C",
+                "text_mid": "#5A5A5A",
                 "text_light": "#8A8A8A",
-                "bg":         "#FFFEF8",
-                "bg_alt":     "#F5F3ED",
-                "bg_accent":  "#EDE8DC",
-                "border":     "#C8C0B0",
+                "bg": "#FFFEF8",
+                "bg_alt": "#F5F3ED",
+                "bg_accent": "#EDE8DC",
+                "border": "#C8C0B0",
             },
             fonts={
-                "title": 32, "subtitle": 24, "heading": 20,
-                "body": 18, "caption": 14, "small": 11,
+                "title": 32,
+                "subtitle": 24,
+                "heading": 20,
+                "body": 18,
+                "caption": 14,
+                "small": 11,
             },
             font_family="Georgia",
             font_mono="Consolas",
+            spacing={
+                "xs": 0.1,
+                "sm": 0.2,
+                "md": 0.4,
+                "lg": 0.75,
+                "xl": 1.2,
+                "2xl": 2.0,
+            },
+            radius={
+                "none": 0.0,
+                "sm": 0.04,
+                "md": 0.1,
+                "lg": 0.22,
+                "full": 99.0,
+            },
+            shadow={
+                "sm": {
+                    "dx": 0.02,
+                    "dy": 0.03,
+                    "blur": 0.12,
+                    "color": "#C8C0B0",
+                    "opacity": 0.25,
+                },
+                "md": {
+                    "dx": 0.04,
+                    "dy": 0.05,
+                    "blur": 0.18,
+                    "color": "#C8C0B0",
+                    "opacity": 0.35,
+                },
+                "lg": {
+                    "dx": 0.07,
+                    "dy": 0.09,
+                    "blur": 0.28,
+                    "color": "#C8C0B0",
+                    "opacity": 0.45,
+                },
+            },
+            duration={
+                "instant": 0.0,
+                "fast": 0.18,
+                "base": 0.42,
+                "slow": 0.85,
+            },
+            density="normal",
+            baseline=0.11,
         )
 
 

--- a/src/paperops/slides/core/tokens.py
+++ b/src/paperops/slides/core/tokens.py
@@ -1,0 +1,363 @@
+"""Token parsing and resolution helpers for the slide DSL foundation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Any
+
+
+class UnknownTokenError(ValueError):
+    """Raised when a token name is not defined for a token category."""
+
+    def __init__(self, category: str, token: Any, available: list[str]):
+        self.category = category
+        self.token = token
+        self.available = available
+        super().__init__(f"Unknown {category} token {token!r}. Available: {available}")
+
+
+class UnknownTokenCategoryError(ValueError):
+    """Raised when an unsupported token category is requested."""
+
+
+@dataclass(frozen=True)
+class ShadowSpec:
+    """Resolved shadow token value."""
+
+    dx: float
+    dy: float
+    blur: float
+    color: str
+    opacity: float = 1.0
+
+    def as_dict(self) -> dict[str, float | str]:
+        return {
+            "dx": self.dx,
+            "dy": self.dy,
+            "blur": self.blur,
+            "color": self.color,
+            "opacity": self.opacity,
+        }
+
+
+class _UnitConverter:
+    _REGEX = re.compile(
+        r"^\s*(?P<number>[-+]?(?:\d+(?:\.\d+)?|\.\d+))(?:\s*(?P<unit>[a-zA-Z]+))?\s*$"
+    )
+
+    @staticmethod
+    def parse(value: str) -> tuple[float, str | None]:
+        match = _UnitConverter._REGEX.match(value)
+        if not match:
+            raise ValueError(f"Invalid numeric token value: {value!r}")
+        number = float(match.group("number"))
+        unit = match.group("unit")
+        return number, unit.lower() if unit else None
+
+
+def _as_float(value: Any, category: str, available: list[str] | None = None) -> float:
+    if isinstance(value, bool):
+        raise TypeError(f"Invalid {category} value: {value!r}")
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            pass
+    if available is not None:
+        raise UnknownTokenError(category, value, available)
+    raise TypeError(f"Invalid {category} value: {value!r}")
+
+
+def _ensure_hex(value: Any, category: str, available: list[str] | None = None) -> str:
+    if isinstance(value, tuple) and len(value) == 3:
+        r, g, b = value
+        return f"#{int(r):02X}{int(g):02X}{int(b):02X}"
+    if isinstance(value, str):
+        if value.startswith("#"):
+            if len(value) == 7 and all(
+                ch in "0123456789abcdefABCDEF" for ch in value[1:]
+            ):
+                return value
+            if value.lower() == "inherit" or value.lower() == "auto":
+                return value.lower()
+        if value in available or available is not None:
+            if available is not None and value in available:
+                return value
+            raise UnknownTokenError(category, value, available)
+    raise TypeError(f"Invalid {category} value: {value!r}")
+
+
+def _resolve_color(theme, value: Any):
+    available = sorted(theme.colors.keys())
+    if value == "inherit" or value == "auto":
+        return value
+    if isinstance(value, (tuple, list)) and len(value) == 3:
+        return _ensure_hex(tuple(value), "colors", None)
+    if isinstance(value, str):
+        if value.startswith("#"):
+            if len(value) == 7 and all(
+                ch in "0123456789abcdefABCDEF" for ch in value[1:]
+            ):
+                return value
+            raise ValueError(f"Invalid color value: {value!r}")
+        if value in theme.colors:
+            return theme.colors[value]
+    if isinstance(value, int | float):
+        raise TypeError(
+            "Numeric colors are unsupported. Use a hex color (e.g. '#3B6B9D') "
+            "or a color token name."
+        )
+    raise UnknownTokenError("colors", value, available)
+
+
+def _resolve_fonts(theme, value: Any):
+    available = sorted(theme.fonts.keys())
+    if value == "inherit" or value == "auto":
+        return value
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        if value in theme.fonts:
+            return float(theme.fonts[value])
+        value = value.strip()
+        if (
+            value.endswith("pt")
+            or value.endswith("in")
+            or value.endswith("px")
+            or value.endswith("em")
+            or value.endswith("rem")
+        ):
+            try:
+                number, unit = _UnitConverter.parse(value)
+            except ValueError as exc:
+                raise UnknownTokenError("fonts", value, available) from exc
+            if unit == "pt":
+                return float(number)
+            if unit == "px":
+                return float(number) / 96 * 72
+            if unit in {"in", "inch", "inches"}:
+                return float(number) * 72
+            if unit == "em":
+                base_font = float(theme.fonts.get("body", 16))
+                return float(number) * base_font
+            if unit == "rem":
+                base_font = float(theme.fonts.get("body", 16))
+                return float(number) * base_font
+            raise ValueError(f"Unsupported font size unit: {value!r}")
+        try:
+            return float(value)
+        except ValueError:
+            raise UnknownTokenError("fonts", value, available)
+    raise UnknownTokenError("fonts", value, available)
+
+
+def _resolve_spacing(theme, value: Any):
+    available = sorted(theme.spacing.keys())
+    if value == "inherit" or value == "auto":
+        return value
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        if value in theme.spacing:
+            return float(theme.spacing[value])
+        value = value.strip()
+        try:
+            number, unit = _UnitConverter.parse(value)
+        except ValueError as exc:
+            raise UnknownTokenError("spacing", value, available) from exc
+        if not unit:
+            return float(number)
+        if unit == "in":
+            return float(number)
+        if unit == "pt":
+            return float(number) / 72.0
+        if unit == "px":
+            return float(number) / 96.0
+        if unit == "cm":
+            return float(number) / 2.54
+        if unit == "mm":
+            return float(number) / 25.4
+        raise ValueError(f"Unsupported spacing unit: {value!r}")
+    raise UnknownTokenError("spacing", value, available)
+
+
+def _resolve_radius(theme, value: Any):
+    available = sorted(theme.radius.keys())
+    if value == "inherit" or value == "auto":
+        return value
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        if value in theme.radius:
+            return float(theme.radius[value])
+        value = value.strip()
+        try:
+            number, unit = _UnitConverter.parse(value)
+        except ValueError as exc:
+            raise UnknownTokenError("radius", value, available) from exc
+        if not unit:
+            return float(number)
+        if unit == "in":
+            return float(number)
+        if unit == "px":
+            return float(number) / 96.0
+        if unit == "pt":
+            return float(number) / 72.0
+        raise ValueError(f"Unsupported radius unit: {value!r}")
+    raise UnknownTokenError("radius", value, available)
+
+
+def _resolve_duration(theme, value: Any):
+    available = sorted(theme.duration.keys())
+    if value == "inherit" or value == "auto":
+        return value
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        if value in theme.duration:
+            return float(theme.duration[value])
+        value = value.strip()
+        try:
+            number, unit = _UnitConverter.parse(value)
+        except ValueError as exc:
+            raise UnknownTokenError("duration", value, available) from exc
+        if not unit:
+            return float(number)
+        if unit == "s":
+            return float(number)
+        if unit == "ms":
+            return float(number) / 1000
+        raise ValueError(f"Unsupported duration unit: {value!r}")
+    raise UnknownTokenError("duration", value, available)
+
+
+def _resolve_shadow(theme, value: Any):
+    available = sorted(theme.shadow.keys())
+    if value == "inherit" or value == "auto":
+        return value
+    if isinstance(value, str) and value in theme.shadow:
+        spec = theme.shadow[value]
+    elif isinstance(value, dict):
+        if "dx" not in value or "dy" not in value:
+            raise ValueError(
+                "Shadow token dictionary must contain at least 'dx' and 'dy'"
+            )
+        spec = {
+            "dx": value["dx"],
+            "dy": value["dy"],
+            "blur": value["blur"],
+            "color": value.get("color", "#000000"),
+            "opacity": value.get("opacity", 1.0),
+        }
+    elif isinstance(value, (tuple, list)):
+        if len(value) != 5:
+            raise ValueError(
+                "Shadow token sequence must be [dx, dy, blur, color, opacity]"
+            )
+        spec = {
+            "dx": value[0],
+            "dy": value[1],
+            "blur": value[2],
+            "color": value[3],
+            "opacity": value[4],
+        }
+    elif value in theme.shadow:
+        spec = theme.shadow[value]
+    else:
+        raise UnknownTokenError("shadow", value, available)
+
+    if isinstance(spec, ShadowSpec):
+        return spec
+    return ShadowSpec(
+        dx=float(spec["dx"]),
+        dy=float(spec["dy"]),
+        blur=float(spec["blur"]),
+        color=(
+            _resolve_color(theme, spec["color"])
+            if isinstance(spec, dict)
+            else _ensure_hex(spec["color"], "shadow", None)
+        ),
+        opacity=float(spec.get("opacity", 1.0)),
+    )
+
+
+def _resolve_density(theme, value: Any):
+    allowed = {"compact", "normal", "airy"}
+    if value == "inherit" or value == "auto":
+        return value
+    if not isinstance(value, str):
+        raise TypeError(f"Invalid density value: {value!r}")
+    if value not in allowed:
+        raise UnknownTokenError("density", value, sorted(allowed))
+    return value
+
+
+def _resolve_baseline(theme, value: Any):
+    available = ["baseline"]
+    if value == "inherit" or value == "auto":
+        return value
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            number, unit = _UnitConverter.parse(value)
+        except ValueError:
+            raise UnknownTokenError("baseline", value, available)
+        if unit is None:
+            return float(number)
+        if unit == "in":
+            return float(number)
+        if unit == "pt":
+            return float(number) / 72.0
+        raise ValueError(f"Unsupported baseline unit: {value!r}")
+    raise UnknownTokenError("baseline", value, available)
+
+
+def resolve_token(theme, category: str, value: Any):
+    """Resolve a style token with a single entrypoint.
+
+    Supported `category` values:
+      - "colors"
+      - "fonts"
+      - "spacing"
+      - "radius"
+      - "shadow"
+      - "duration"
+      - "density"
+      - "baseline"
+
+    Supported value types:
+      - token name (resolved from the theme map)
+      - number (returned as float)
+      - unit strings like "0.5in", "12pt"
+      - hex colors for color category
+      - "inherit" / "auto" passthrough
+    """
+
+    match category:
+        case "colors":
+            return _resolve_color(theme, value)
+        case "fonts":
+            return _resolve_fonts(theme, value)
+        case "spacing":
+            return _resolve_spacing(theme, value)
+        case "radius":
+            return _resolve_radius(theme, value)
+        case "shadow":
+            return _resolve_shadow(theme, value)
+        case "duration":
+            return _resolve_duration(theme, value)
+        case "density":
+            return _resolve_density(theme, value)
+        case "baseline":
+            return _resolve_baseline(theme, value)
+        case _:
+            raise UnknownTokenCategoryError(f"Unknown token category: {category!r}")
+
+
+def resolve(theme, category: str, value: Any):
+    """Backward-compatible alias for resolve_token."""
+    return resolve_token(theme, category, value)

--- a/src/paperops/slides/ir/__init__.py
+++ b/src/paperops/slides/ir/__init__.py
@@ -1,0 +1,13 @@
+"""IR layer exports."""
+
+from paperops.slides.ir.node import Node
+from paperops.slides.ir.schema import IR_DOCUMENT_SCHEMA, IR_NODE_SCHEMA, STYLE_KEY_SCHEMAS, validate_document, validate_node
+
+__all__ = [
+    "IR_DOCUMENT_SCHEMA",
+    "IR_NODE_SCHEMA",
+    "Node",
+    "STYLE_KEY_SCHEMAS",
+    "validate_document",
+    "validate_node",
+]

--- a/src/paperops/slides/ir/node.py
+++ b/src/paperops/slides/ir/node.py
@@ -1,0 +1,81 @@
+"""Canonical JSON IR node model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Union
+
+from paperops.slides.ir import schema
+
+NodeChild = Union[str, "Node"]
+
+
+@dataclass(frozen=True)
+class Node:
+    """A single IR node.
+
+    Fields are normalized to a JSON-friendly shape and can be serialized back
+    without information loss.
+    """
+
+    type: str
+    class_: str | None = None
+    id: str | None = None
+    style: dict[str, Any] | None = None
+    props: dict[str, Any] | None = None
+    children: list[NodeChild] | None = None
+
+    def __post_init__(self):
+        if not self.type or not isinstance(self.type, str):
+            raise TypeError("Node.type is required and must be a string")
+        if self.class_ is not None and not isinstance(self.class_, str):
+            raise TypeError("Node.class must be a string when set")
+        if self.id is not None and not isinstance(self.id, str):
+            raise TypeError("Node.id must be a string when set")
+        if self.style is not None and not isinstance(self.style, dict):
+            raise TypeError("Node.style must be a mapping when set")
+        if self.props is not None and not isinstance(self.props, dict):
+            raise TypeError("Node.props must be a mapping when set")
+
+        if self.children is not None:
+            for child in self.children:
+                if not isinstance(child, (str, Node)):
+                    raise TypeError(
+                        "Node.children may only contain strings or Node instances"
+                    )
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {"type": self.type}
+        if self.class_ is not None:
+            payload["class"] = self.class_
+        if self.id is not None:
+            payload["id"] = self.id
+        if self.style is not None:
+            payload["style"] = self.style
+        if self.props is not None:
+            payload["props"] = self.props
+        if self.children is not None:
+            payload["children"] = [
+                child.to_dict() if isinstance(child, Node) else child
+                for child in self.children
+            ]
+        return payload
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "Node":
+        schema.validate_node(raw)
+        return cls(
+            type=raw["type"],
+            class_=raw.get("class"),
+            id=raw.get("id"),
+            style=raw.get("style"),
+            props=raw.get("props"),
+            children=(
+                [
+                    item if isinstance(item, str) else cls.from_dict(item)
+                    for item in raw.get("children", [])
+                ]
+                if "children" in raw
+                else None
+            ),
+        )

--- a/src/paperops/slides/ir/schema.py
+++ b/src/paperops/slides/ir/schema.py
@@ -1,0 +1,288 @@
+"""JSON Schema definitions for the slide DSL canonical IR.
+
+This module provides both the schema dictionaries (draft 2020-12 shape) and small
+lightweight runtime validators for project-local test assertions.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from paperops.slides.core.tokens import ShadowSpec
+
+STYLE_KEY_SCHEMAS: dict[str, dict[str, Any]] = {
+    "color": {
+        "type": ["string", "number", "null"],
+        "description": "Color token or hex value",
+    },
+    "bg": {
+        "type": ["string", "number", "null"],
+        "description": "Background color token",
+    },
+    "border": {
+        "type": ["string", "number", "null"],
+        "description": "Border color or style spec",
+    },
+    "border-left": {
+        "type": ["string", "number", "array", "null"],
+        "description": "Border-left shorthand",
+    },
+    "padding": {
+        "type": ["string", "number", "null"],
+        "description": "Shorthand spacing",
+    },
+    "padding-x": {
+        "type": ["string", "number", "null"],
+        "description": "Horizontal padding",
+    },
+    "padding-y": {
+        "type": ["string", "number", "null"],
+        "description": "Vertical padding",
+    },
+    "padding-top": {"type": ["string", "number", "null"]},
+    "padding-right": {"type": ["string", "number", "null"]},
+    "padding-bottom": {"type": ["string", "number", "null"]},
+    "padding-left": {"type": ["string", "number", "null"]},
+    "margin": {"type": ["string", "number", "null"]},
+    "margin-x": {"type": ["string", "number", "null"]},
+    "margin-y": {"type": ["string", "number", "null"]},
+    "margin-top": {"type": ["string", "number", "null"]},
+    "margin-right": {"type": ["string", "number", "null"]},
+    "margin-bottom": {"type": ["string", "number", "null"]},
+    "margin-left": {"type": ["string", "number", "null"]},
+    "radius": {"type": ["string", "number", "null"]},
+    "shadow": {"type": ["string", "array", "null", "object"]},
+    "opacity": {"type": ["number", "null"]},
+    "width": {"type": ["string", "number", "null"]},
+    "height": {"type": ["string", "number", "null"]},
+    "gap": {"type": ["string", "number", "null"]},
+    "row-gap": {"type": ["string", "number", "null"]},
+    "column-gap": {"type": ["string", "number", "null"]},
+    "cols": {"type": ["string", "number", "null"]},
+    "rows": {"type": ["string", "number", "null"]},
+    "justify": {"type": ["string", "null"]},
+    "align": {"type": ["string", "null"]},
+    "align-items": {"type": ["string", "null"]},
+    "align-self": {"type": ["string", "null"]},
+    "overflow": {"type": ["string", "null"]},
+    "max-lines": {"type": ["integer", "string", "null"]},
+    "font": {"type": ["string", "number", "null"]},
+    "font-family": {"type": ["string", "null"]},
+    "font-weight": {"type": ["string", "number", "null"]},
+    "font-style": {"type": ["string", "null"]},
+    "line-height": {"type": ["number", "string", "null"]},
+    "letter-spacing": {"type": ["number", "string", "null"]},
+    "text-align": {"type": ["string", "null"]},
+    "text-transform": {"type": ["string", "null"]},
+    "animate": {"type": ["string", "null"]},
+    "delay": {"type": ["string", "number", "null"]},
+    "duration": {"type": ["string", "number", "null"]},
+    "stagger": {"type": ["string", "number", "null"]},
+    "animate-trigger": {"type": ["string", "null"]},
+    "animate-group": {"type": ["string", "null"]},
+    "grow": {"type": ["number", "null"]},
+    "shrink": {"type": ["number", "null"]},
+    "basis": {"type": ["string", "number", "null"]},
+    "wrap": {"type": ["string", "boolean", "null"]},
+    "aspect-ratio": {"type": ["string", "number", "null"]},
+}
+
+STYLE_VALUE_SCHEMA: dict[str, Any] = {
+    "anyOf": [
+        {"type": "string"},
+        {"type": "number"},
+        {"type": "integer"},
+        {"type": "boolean"},
+        {"type": "array"},
+        {"type": "object"},
+        {"type": "null"},
+    ]
+}
+
+IR_NODE_SCHEMA: dict[str, Any] = {
+    "$id": "https://paperops.dev/schema/slide-dsl-node.json",
+    "type": "object",
+    "required": ["type"],
+    "properties": {
+        "type": {"type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_-]*$"},
+        "class": {"type": "string"},
+        "id": {"type": "string"},
+        "style": {"$ref": "#/definitions/style"},
+        "props": {"type": "object", "additionalProperties": True},
+        "children": {
+            "type": "array",
+            "items": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"$ref": "#/definitions/node"},
+                ]
+            },
+        },
+    },
+    "additionalProperties": False,
+}
+
+IR_DOCUMENT_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://paperops.dev/schema/slide-dsl.json",
+    "title": "paperops.slide.dsl",
+    "type": "object",
+    "required": ["slides"],
+    "properties": {
+        "$schema": {"type": "string"},
+        "meta": {"type": "object", "additionalProperties": True},
+        "theme": {"type": "string"},
+        "sheet": {"type": "string"},
+        "styles": {
+            "type": "object",
+            "additionalProperties": {"$ref": "#/definitions/style"},
+        },
+        "defines": {
+            "type": "object",
+            "additionalProperties": {"$ref": "#/definitions/node"},
+        },
+        "slides": {
+            "type": "array",
+            "minItems": 1,
+            "items": {"$ref": "#/definitions/node"},
+        },
+    },
+    "additionalProperties": False,
+    "definitions": {
+        "style": {
+            "type": "object",
+            "patternProperties": {
+                "^.*$": STYLE_VALUE_SCHEMA,
+            },
+            "additionalProperties": False,
+            "properties": {key: val for key, val in STYLE_KEY_SCHEMAS.items()},
+        },
+        "node": {"$ref": "#/"},  # will be normalized by runtime validators
+    },
+}
+
+# Keep recursive schemas valid JSON-like for introspection.
+IR_DOCUMENT_SCHEMA["definitions"]["node"] = {
+    "type": "object",
+    "required": ["type"],
+    "properties": IR_NODE_SCHEMA["properties"],
+    "additionalProperties": False,
+    "$recursiveRef": "#",
+}
+
+
+def _validate_node_type(value: Any) -> None:
+    if not isinstance(value, str) or not value:
+        raise ValueError("Node 'type' must be a non-empty string")
+
+
+def _validate_style_value(value: Any, schema: dict[str, Any]) -> None:
+    allowed_types = set(schema.get("type", []) or [])
+    if not allowed_types:
+        # fallback: no explicit type constraints
+        return
+
+    for t in allowed_types:
+        if t == "string" and isinstance(value, str):
+            return
+        if t == "number" and isinstance(value, int | float):
+            return
+        if t == "integer" and isinstance(value, int):
+            return
+        if t == "boolean" and isinstance(value, bool):
+            return
+        if t == "array" and isinstance(value, list):
+            return
+        if t == "object" and isinstance(value, dict):
+            return
+        if t == "null" and value is None:
+            return
+    raise TypeError(f"Style value has unsupported type: {type(value)!r}")
+
+
+def _validate_style(style: Any, path: str) -> None:
+    if not isinstance(style, dict):
+        raise TypeError(f"{path}: style must be an object")
+    for key, value in style.items():
+        if not isinstance(key, str):
+            raise TypeError(f"{path}: style key must be a string")
+        value_schema = STYLE_KEY_SCHEMAS.get(key, STYLE_VALUE_SCHEMA)
+        if key not in STYLE_KEY_SCHEMAS and "/definitions/style" in str(value_schema):
+            # no-op placeholder kept for introspection-only schemas
+            continue
+        _validate_style_value(
+            value,
+            value_schema if isinstance(value_schema, dict) else STYLE_VALUE_SCHEMA,
+        )
+
+
+def validate_node(raw: Any, *, path: str = "node") -> None:
+    """Validate a single IR node dictionary.
+
+    This is intentionally strict to ensure phase-0 API expectations are met:
+    - `type` required
+    - no unknown top-level keys
+    - proper child/inline field types
+    """
+    if not isinstance(raw, dict):
+        raise TypeError(f"{path}: node must be a mapping")
+    allowed = set(IR_NODE_SCHEMA["properties"].keys())
+    unknown = set(raw.keys()) - allowed
+    if unknown:
+        raise ValueError(f"{path}: node contains unknown fields: {sorted(unknown)}")
+
+    if "type" not in raw:
+        raise ValueError(f"{path}: missing required field 'type'")
+    _validate_node_type(raw["type"])
+
+    if "class" in raw and not isinstance(raw["class"], str):
+        raise TypeError(f"{path}: class must be string")
+    if "id" in raw and not isinstance(raw["id"], str):
+        raise TypeError(f"{path}: id must be string")
+    if "style" in raw:
+        _validate_style(raw["style"], f"{path}.style")
+    if "props" in raw and not isinstance(raw["props"], dict):
+        raise TypeError(f"{path}: props must be an object")
+    if "children" in raw:
+        children = raw["children"]
+        if not isinstance(children, list):
+            raise TypeError(f"{path}: children must be a list")
+        for idx, child in enumerate(children):
+            if isinstance(child, str):
+                continue
+            if isinstance(child, dict):
+                validate_node(child, path=f"{path}.children[{idx}]")
+                continue
+            raise TypeError(
+                f"{path}.children[{idx}] must be either string or node object"
+            )
+
+
+def validate_document(raw: Any, *, path: str = "document") -> None:
+    if not isinstance(raw, dict):
+        raise TypeError(f"{path}: document must be a mapping")
+    required = set(IR_DOCUMENT_SCHEMA["required"])
+    unknown = set(raw.keys()) - {
+        "$schema",
+        "meta",
+        "theme",
+        "sheet",
+        "styles",
+        "defines",
+        "slides",
+    }
+    if unknown:
+        raise ValueError(f"{path}: document contains unknown fields: {sorted(unknown)}")
+    missing = required - set(raw.keys())
+    if missing:
+        raise ValueError(
+            f"{path}: document missing required field(s): {sorted(missing)}"
+        )
+    if not isinstance(raw.get("slides"), list):
+        raise TypeError(f"{path}.slides must be a list")
+    if not raw["slides"]:
+        raise ValueError(f"{path}.slides must contain at least one node")
+    for idx, slide in enumerate(raw["slides"]):
+        if not isinstance(slide, dict):
+            raise TypeError(f"{path}.slides[{idx}] must be a node object")
+        validate_node(slide, path=f"{path}.slides[{idx}]")

--- a/tests/components/test_registry.py
+++ b/tests/components/test_registry.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+
+from paperops.slides.components.registry import (
+    ComponentDefinition,
+    ComponentRegistry,
+    register_component,
+    registry,
+)
+
+
+def test_register_component_and_get_definition(monkeypatch):
+    # keep global registry deterministic and isolated for this test
+    original_state = registry._definitions.copy()
+    registry._definitions.clear()
+
+    try:
+
+        @register_component(
+            "kpi",
+            props_schema={"value": {"type": "number"}},
+            default_classes=["metric", "card"],
+        )
+        class KpiDefinition:
+            pass
+
+        assert registry.has("kpi")
+        definition = registry.get("kpi")
+        assert isinstance(definition, ComponentDefinition)
+        assert definition.type == "kpi"
+        assert definition.props_schema == {"value": {"type": "number"}}
+        assert definition.default_classes == ["metric", "card"]
+    finally:
+        registry._definitions.clear()
+        registry._definitions.update(original_state)
+
+
+def test_duplicate_component_registration_raises_error():
+    local_registry = ComponentRegistry()
+    local_registry.register("kpi", ComponentDefinition(type="kpi"))
+
+    with pytest.raises(ValueError, match="already registered"):
+        local_registry.register("kpi", ComponentDefinition(type="kpi"))

--- a/tests/core/test_theme_tokens.py
+++ b/tests/core/test_theme_tokens.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from paperops.slides.core import (
+    UnknownTokenCategoryError,
+    UnknownTokenError,
+    resolve,
+    themes,
+)
+
+
+def test_resolve_theme_spacing_token_must_be_float():
+    executive = themes.executive
+
+    assert executive.resolve_token("spacing", "md") == 0.32
+
+
+def test_resolve_theme_color_token_returns_hex():
+    professional = themes.professional
+
+    assert isinstance(professional.resolve_token("colors", "primary"), str)
+    assert professional.resolve_token("colors", "primary") == "#3B6B9D"
+
+
+def test_resolve_with_unit_string_is_preserved_as_inches():
+    executive = themes.executive
+
+    assert executive.resolve_token("spacing", "0.5in") == 0.5
+    assert isinstance(executive.resolve_token("fonts", "12pt"), float)
+
+
+def test_unknown_token_raises_with_available_list():
+    minimal = themes.minimal
+
+    try:
+        minimal.resolve_token("spacing", "absurd")
+        raise AssertionError("Expected UnknownTokenError")
+    except UnknownTokenError as err:
+        assert err.token == "absurd"
+        assert err.category == "spacing"
+        assert "Available" in err.args[0]
+        assert "md" in err.available
+
+
+def test_resolve_color_supports_hex_and_auto_inherit_values():
+    academic = themes.academic
+
+    assert academic.resolve_token("colors", "#123ABC") == "#123ABC"
+    assert academic.resolve_token("spacing", "auto") == "auto"
+    assert academic.resolve_token("spacing", "inherit") == "inherit"
+
+
+def test_resolve_shadow_resolves_named_shadow_spec():
+    executive = themes.executive
+
+    shadow = executive.resolve_token("shadow", "sm")
+    assert shadow.dx > 0
+    assert shadow.color == "#C5CBD3"
+
+
+def test_resolve_raises_for_unknown_category():
+    base = themes.academic
+
+    try:
+        resolve(base, "unsupported", "md")
+        raise AssertionError("Expected UnknownTokenCategoryError")
+    except UnknownTokenCategoryError:
+        pass

--- a/tests/ir/test_node.py
+++ b/tests/ir/test_node.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from paperops.slides.ir import Node
+
+
+def test_node_round_trip_with_children_and_strings():
+    node = Node(
+        type="slide",
+        class_="cover hero",
+        id="hero-slide",
+        style={"bg": "bg_alt", "padding": "lg"},
+        props={"align": "center"},
+        children=[
+            "intro",
+            Node(type="text", props={"value": "hello"}),
+        ],
+    )
+
+    roundtrip = Node.from_dict(node.to_dict())
+
+    assert roundtrip == node
+    assert roundtrip.children is not None
+    assert roundtrip.children[0] == "intro"
+    assert isinstance(roundtrip.children[1], Node)
+
+
+def test_node_rejects_invalid_type_and_children_in_schema_validation():
+    base = {
+        "class": "test",
+        "children": ["ok"],
+    }
+    try:
+        Node.from_dict(base)
+        raise AssertionError("Expected ValueError")
+    except ValueError as err:
+        assert "missing required field 'type'" in str(err)
+
+
+def test_node_invalid_child_type_is_rejected_by_from_dict():
+    invalid = {
+        "type": "slide",
+        "children": [123],
+    }
+    try:
+        Node.from_dict(invalid)
+        raise AssertionError("Expected TypeError")
+    except TypeError as err:
+        assert "must be either string or node object" in str(err)

--- a/tests/ir/test_schema.py
+++ b/tests/ir/test_schema.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pytest
+
+from paperops.slides.ir import IR_DOCUMENT_SCHEMA, validate_document, validate_node
+
+
+def test_validate_node_accepts_valid_node():
+    node = {
+        "type": "card",
+        "class": "kpi",
+        "id": "node-1",
+        "style": {"padding": "md", "font": "body", "radius": 0.12},
+        "props": {"value": 10},
+        "children": ["text", {"type": "text", "children": ["Hello"]}],
+    }
+
+    validate_node(node)
+
+
+def test_validate_node_rejects_missing_type():
+    with pytest.raises(ValueError, match="missing required"):
+        validate_node({"class": "kpi"})
+
+
+def test_validate_node_rejects_unknown_field():
+    with pytest.raises(ValueError, match="unknown fields"):
+        validate_node({"type": "kpi", "class": "a", "unknown": 1})
+
+
+def test_validate_node_rejects_non_string_class():
+    with pytest.raises(TypeError, match="class must be string"):
+        validate_node({"type": "kpi", "class": 1})
+
+
+def test_validate_document_round_trip_shape_is_accepted():
+    document = {
+        "$schema": "paperops-slide-1.0",
+        "meta": {"title": "phase 0"},
+        "theme": "minimal",
+        "slides": [
+            {
+                "type": "slide",
+                "children": [{"type": "text", "children": ["hello"]}],
+            }
+        ],
+    }
+
+    validate_document(document)
+
+
+def test_validate_document_rejects_unknown_top_key():
+    with pytest.raises(ValueError, match="unknown fields"):
+        validate_document({"slides": [{"type": "slide"}], "oops": 1})


### PR DESCRIPTION
Implements Phase 0 DSL foundation from docs/design/slide-dsl.md.

## Summary
- Reworked `src/paperops/slides/core/theme.py` into a token container with required token validation.
- Added unified token parser in `src/paperops/slides/core/tokens.py`.
- Added canonical IR model in `src/paperops/slides/ir/node.py` with strict round-trip behavior.
- Added IR JSON Schema and validators in `src/paperops/slides/ir/schema.py`.
- Added component registry and decorator in `src/paperops/slides/components/registry.py`.
- Added tests for phase 0 APIs in `tests/core/test_theme_tokens.py`, `tests/ir/test_node.py`, `tests/ir/test_schema.py`, and `tests/components/test_registry.py`.

## Acceptance criteria checks
- `theme.resolve_token("spacing", "md")` returns expected spacing token.
- `theme.resolve_token("colors", "primary")` returns hex color.
- `theme.resolve_token("spacing", "0.5in")` resolves to 0.5.
- Unknown token names raise `UnknownTokenError` and include available token names.
- `Node.from_dict(node.to_dict()) == node` for round-trip validation.
- JSON schema validation rejects missing `type`, unknown fields, and non-string `class`.
- `@register_component("kpi")` populates global registry; duplicate registration is rejected.

Command run:
`uv run pytest tests/core tests/ir tests/components/test_registry.py`
