### PR TITLE
[Phase 1] Implement CSS-style StyleSheet, selector matching, cascade, and inheritance

### DIFF
--- a/src/paperops/slides/style/__init__.py
+++ b/src/paperops/slides/style/__init__.py
@@ -1,0 +1,25 @@
+"""Style resolution primitives for `paperops.slides`.
+
+The package exposes a compact CSS-like engine used by the IR pipeline:
+selectors, stylesheet ordering, cascade/inheritance, and resolved style values.
+"""
+
+from paperops.slides.style.computed import ComputedStyle
+from paperops.slides.style.cascade import (
+    CascadeResult,
+    StyleResolutionError,
+    resolve_computed_styles,
+)
+from paperops.slides.style.selector import ParsedSelector, parse_selector, specificity
+from paperops.slides.style.stylesheet import StyleSheet
+
+__all__ = [
+    "CascadeResult",
+    "ComputedStyle",
+    "ParsedSelector",
+    "StyleResolutionError",
+    "StyleSheet",
+    "parse_selector",
+    "resolve_computed_styles",
+    "specificity",
+]

--- a/src/paperops/slides/style/cascade.py
+++ b/src/paperops/slides/style/cascade.py
@@ -1,0 +1,457 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+from paperops.slides.core.theme import Theme
+from paperops.slides.core.tokens import UnknownTokenCategoryError, UnknownTokenError
+from paperops.slides.ir.node import Node
+from paperops.slides.ir.schema import STYLE_KEY_SCHEMAS
+from paperops.slides.style.computed import ComputedStyle
+from paperops.slides.style.selector import matches_selector
+from paperops.slides.style.stylesheet import StyleSheet
+
+
+_KNOWN_STYLE_KEYS = set(STYLE_KEY_SCHEMAS.keys()) | {"lang"}
+_INHERITABLE_STYLE_KEYS = {
+    "color",
+    "font",
+    "font-family",
+    "font-weight",
+    "font-style",
+    "line-height",
+    "text-align",
+    "lang",
+}
+
+_BLACKLIST_STYLE_KEYS: dict[str, dict[str, list[str] | str]] = {
+    "display": {
+        "hint": "Layout is selected by component type, not CSS display.",
+        "suggestions": ["<Flex>", "<Grid>", "<Stack>", "<Absolute>"],
+    },
+    "position": {
+        "hint": "Absolute positioning is a component-level concern in paperops.",
+        "suggestions": ["<Absolute>"],
+    },
+    "float": {
+        "hint": "Float-based layout is unsupported in this DSL.",
+        "suggestions": ["<Grid>"],
+    },
+    "clear": {
+        "hint": "Float-clearing is unsupported in this DSL.",
+        "suggestions": ["<Grid>"],
+    },
+    "z-index": {
+        "hint": "Stacking order is component-based and explicit in <Layer>.",
+        "suggestions": ["<Layer>"],
+    },
+    "transform": {
+        "hint": "Use animation or components instead of CSS transform.",
+        "suggestions": ["<Rotate>", "<Scale>", "animate"],
+    },
+    "transition": {
+        "hint": "Transitions are handled with animation keys.",
+        "suggestions": ["animate", "duration"],
+    },
+}
+
+_COLOR_KEYS = {
+    "color",
+    "bg",
+    "border",
+    "border-left",
+    "border-top",
+    "border-right",
+    "border-bottom",
+}
+_FONT_KEYS = {"font"}
+_SPACING_KEYS = {
+    "padding",
+    "padding-x",
+    "padding-y",
+    "padding-top",
+    "padding-right",
+    "padding-bottom",
+    "padding-left",
+    "margin",
+    "margin-x",
+    "margin-y",
+    "margin-top",
+    "margin-right",
+    "margin-bottom",
+    "margin-left",
+    "gap",
+    "row-gap",
+    "column-gap",
+    "width",
+    "height",
+    "min-width",
+    "max-width",
+    "min-height",
+    "max-height",
+    "aspect-ratio",
+    "cols",
+    "rows",
+}
+_SHADOW_KEYS = {"shadow"}
+_DURATION_KEYS = {"duration", "delay", "stagger"}
+
+
+@dataclass(frozen=True)
+class StyleResolutionError(ValueError):
+    """Structured style error used by the style engine."""
+
+    code: str
+    message: str
+    path: str
+    key: str
+    hint: str | None = None
+    suggestion: list[str] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = {
+            "code": self.code,
+            "message": self.message,
+            "path": self.path,
+            "key": self.key,
+        }
+        if self.hint is not None:
+            payload["hint"] = self.hint
+        if self.suggestion is not None:
+            payload["suggestion"] = self.suggestion
+        return payload
+
+
+@dataclass(frozen=True)
+class CascadeResult:
+    """Computed style output for an IR tree."""
+
+    computed: dict[int, ComputedStyle]
+    errors: list[StyleResolutionError]
+    root: Node | None = None
+
+    def style_for(self, node_or_id: Node | int) -> ComputedStyle:
+        key = node_or_id if isinstance(node_or_id, int) else id(node_or_id)
+        return self.computed[key]
+
+    def __getitem__(self, node_or_id: Node | int) -> ComputedStyle:
+        return self.style_for(node_or_id)
+
+
+def resolve_computed_styles(
+    root: Node | Mapping[str, Any],
+    *,
+    theme: Theme,
+    theme_defaults: Mapping[str, Mapping[str, Any]] | None = None,
+    style_sheet: StyleSheet | Mapping[str, Mapping[str, Any]] | None = None,
+    deck_style: StyleSheet | Mapping[str, Mapping[str, Any]] | None = None,
+    strict: bool = True,
+) -> CascadeResult:
+    """Compute ComputedStyle for every node in an IR tree."""
+    sheet = _as_stylesheet(style_sheet)
+    deck = _as_stylesheet(deck_style)
+    defaults = dict(theme_defaults or {})
+    computed: dict[int, ComputedStyle] = {}
+    errors: list[StyleResolutionError] = []
+
+    root_node = _coerce_node(root, path="root")
+    _walk_node(
+        root_node,
+        ancestors=(),
+        sibling_meta=(None,),
+        theme=theme,
+        defaults=defaults,
+        style_sheet=sheet,
+        deck_style=deck,
+        path="root",
+        parent_computed=None,
+        computed=computed,
+        errors=errors,
+    )
+
+    if strict and errors:
+        raise errors[0]
+    return CascadeResult(computed=computed, errors=errors, root=root_node)
+
+
+def _walk_node(
+    node: Node,
+    *,
+    ancestors: tuple[Node, ...],
+    sibling_meta: tuple[tuple[int, int] | None, ...],
+    theme: Theme,
+    defaults: Mapping[str, Mapping[str, Any]],
+    style_sheet: StyleSheet,
+    deck_style: StyleSheet,
+    path: str,
+    parent_computed: ComputedStyle | None,
+    computed: dict[int, ComputedStyle],
+    errors: list[StyleResolutionError],
+) -> None:
+    current_computed = _compute_node_style(
+        node=node,
+        theme=theme,
+        defaults=defaults,
+        style_sheet=style_sheet,
+        deck_style=deck_style,
+        ancestors=ancestors,
+        sibling_meta=sibling_meta,
+        parent_style=parent_computed,
+        path=path,
+        errors=errors,
+    )
+    object.__setattr__(node, "computed_style", current_computed)
+    computed[id(node)] = current_computed
+
+    children = _node_children(node)
+    if not children:
+        return
+
+    totals = _same_type_counts(children)
+    running = {}
+
+    for index, child in enumerate(children):
+        if not isinstance(child, Node):
+            continue
+        next_meta = _same_type_meta(child, totals, running)
+        _walk_node(
+            child,
+            ancestors=(*ancestors, node),
+            sibling_meta=(*sibling_meta, next_meta),
+            theme=theme,
+            defaults=defaults,
+            style_sheet=style_sheet,
+            deck_style=deck_style,
+            path=f"{path}.children[{index}]",
+            parent_computed=current_computed,
+            computed=computed,
+            errors=errors,
+        )
+
+
+def _compute_node_style(
+    *,
+    node: Node,
+    theme: Theme,
+    defaults: Mapping[str, Mapping[str, Any]],
+    style_sheet: StyleSheet,
+    deck_style: StyleSheet,
+    ancestors: tuple[Node, ...],
+    sibling_meta: tuple[tuple[int, int] | None, ...],
+    parent_style: ComputedStyle | None,
+    path: str,
+    errors: list[StyleResolutionError],
+) -> ComputedStyle:
+    style_candidates: dict[str, tuple[tuple[int, int, int, int], Any]] = {}
+
+    theme_defaults = defaults.get(node.type, {}) if defaults else {}
+    _apply_style_source(
+        style_candidates,
+        declarations=theme_defaults,
+        origin_rank=0,
+        source_order=0,
+        specificity=0,
+        node=node,
+        theme=theme,
+        path=path,
+        errors=errors,
+    )
+
+    for rule in style_sheet:
+        if matches_selector(rule.selector, node, ancestors, sibling_meta):
+            _apply_style_source(
+                style_candidates,
+                declarations=rule.declarations,
+                origin_rank=1,
+                source_order=rule.source_index,
+                specificity=rule.specificity,
+                node=node,
+                theme=theme,
+                path=path,
+                errors=errors,
+            )
+
+    for rule in deck_style:
+        if matches_selector(rule.selector, node, ancestors, sibling_meta):
+            _apply_style_source(
+                style_candidates,
+                declarations=rule.declarations,
+                origin_rank=2,
+                source_order=rule.source_index,
+                specificity=rule.specificity,
+                node=node,
+                theme=theme,
+                path=path,
+                errors=errors,
+            )
+
+    inline_style = _node_style(node)
+    _apply_style_source(
+        style_candidates,
+        declarations=inline_style,
+        origin_rank=3,
+        source_order=0,
+        specificity=0,
+        node=node,
+        theme=theme,
+        path=path,
+        errors=errors,
+    )
+
+    resolved = {
+        key: value for key, (_, value) in style_candidates.items() if value is not None
+    }
+
+    for key in _INHERITABLE_STYLE_KEYS:
+        if key in resolved and resolved[key] == "inherit":
+            if parent_style is None:
+                resolved.pop(key, None)
+                continue
+            inherited = parent_style.get(key)
+            if inherited is not None:
+                resolved[key] = inherited
+            else:
+                resolved.pop(key, None)
+        elif key not in resolved and parent_style is not None:
+            inherited = parent_style.get(key)
+            if inherited is not None:
+                resolved[key] = inherited
+
+    return ComputedStyle(resolved, parent=parent_style)
+
+
+def _apply_style_source(
+    style_candidates: dict[str, tuple[tuple[int, int, int, int], Any]],
+    declarations: Mapping[str, Any] | None,
+    *,
+    origin_rank: int,
+    source_order: int,
+    specificity: int,
+    node: Node,
+    theme: Theme,
+    path: str,
+    errors: list[StyleResolutionError],
+) -> None:
+    if not declarations:
+        return
+
+    for declaration_index, (key, raw_value) in enumerate(declarations.items()):
+        if key not in _KNOWN_STYLE_KEYS and key not in _BLACKLIST_STYLE_KEYS:
+            errors.append(
+                StyleResolutionError(
+                    code="UNKNOWN_STYLE_KEY",
+                    message=f"Unknown style key: {key!r}",
+                    path=path,
+                    key=key,
+                    hint="Unknown style key is not in the allowlist.",
+                )
+            )
+            continue
+
+        if key in _BLACKLIST_STYLE_KEYS:
+            info = _BLACKLIST_STYLE_KEYS[key]
+            errors.append(
+                StyleResolutionError(
+                    code="UNKNOWN_STYLE_KEY",
+                    message=f"Unknown style key: {key!r}",
+                    path=path,
+                    key=key,
+                    hint=str(info.get("hint", "")),
+                    suggestion=list(info["suggestions"]),
+                )
+            )
+            continue
+
+        try:
+            resolved_value = _resolve_style_value(theme, key, raw_value)
+        except (UnknownTokenCategoryError, UnknownTokenError, TypeError, ValueError) as exc:
+            errors.append(
+                StyleResolutionError(
+                    code="INVALID_STYLE_VALUE",
+                    message=f"Unable to resolve style key {key!r}: {raw_value!r}",
+                    path=path,
+                    key=key,
+                    hint=str(exc),
+                )
+            )
+            continue
+
+        score = (origin_rank, specificity, source_order, declaration_index)
+        prev = style_candidates.get(key)
+        if prev is None or score > prev[0]:
+            style_candidates[key] = (score, resolved_value)
+
+
+def _resolve_style_value(theme: Theme, key: str, value: Any) -> Any:
+    if value in {"inherit", "auto", "none", None}:
+        return value
+
+    if key in _COLOR_KEYS:
+        return theme.resolve_token("colors", value)
+    if key in _FONT_KEYS:
+        return theme.resolve_token("fonts", value)
+    if key in _SPACING_KEYS:
+        return theme.resolve_token("spacing", value)
+    if key in {"radius"}:
+        return theme.resolve_token("radius", value)
+    if key in _SHADOW_KEYS:
+        return theme.resolve_token("shadow", value)
+    if key in _DURATION_KEYS:
+        return theme.resolve_token("duration", value)
+    if key == "line-height" and isinstance(value, str):
+        return float(value) if _is_float(value) else value
+    return value
+
+
+def _is_float(value: str) -> bool:
+    try:
+        float(value)
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
+def _as_stylesheet(
+    sheet: StyleSheet | Mapping[str, Mapping[str, Any]] | None,
+) -> StyleSheet:
+    if sheet is None:
+        return StyleSheet({})
+    if isinstance(sheet, StyleSheet):
+        return sheet
+    return StyleSheet(sheet)
+
+
+def _coerce_node(raw: Node | Mapping[str, Any], path: str) -> Node:
+    if isinstance(raw, Node):
+        return raw
+    if not isinstance(raw, Mapping):
+        raise TypeError(f"{path}: node must be a Node or dict")
+    return Node.from_dict(dict(raw))
+
+
+def _node_children(node: Node) -> Sequence[Node | str] | None:
+    return node.children or None
+
+
+def _node_style(node: Node) -> Mapping[str, Any] | None:
+    return node.style or None
+
+
+def _same_type_counts(children: Sequence[Node | str]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for child in children:
+        if not isinstance(child, Node):
+            continue
+        counts[child.type] = counts.get(child.type, 0) + 1
+    return counts
+
+
+def _same_type_meta(
+    child: Node,
+    totals: dict[str, int],
+    running: dict[str, int],
+) -> tuple[int, int]:
+    current = running.get(child.type, 0) + 1
+    running[child.type] = current
+    return current, totals[child.type]

--- a/src/paperops/slides/style/computed.py
+++ b/src/paperops/slides/style/computed.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+
+_INHERITABLE_KEYS = {
+    "color",
+    "font",
+    "font-family",
+    "font-weight",
+    "font-style",
+    "line-height",
+    "text-align",
+    "lang",
+}
+
+
+@dataclass(frozen=True)
+class ComputedStyle:
+    """Resolved style values for a single IR node.
+
+    Values are resolved and merged according to style cascade and inheritance rules.
+    `get()` follows a fallback chain to parent nodes for inheritable keys.
+    """
+
+    values: Mapping[str, Any] = field(default_factory=dict)
+    parent: "ComputedStyle | None" = None
+
+    def get(self, key: str, default: Any = None) -> Any:
+        if key in self.values:
+            value = self.values[key]
+            if value == "inherit":
+                if self.parent is None:
+                    return default
+                return self.parent.get(key, default)
+            return value
+        if self.parent is None or key not in _INHERITABLE_KEYS:
+            return default
+        return self.parent.get(key, default)
+
+    def snapshot(self) -> dict[str, Any]:
+        merged: dict[str, Any] = {}
+        cursor: ComputedStyle | None = self
+        while cursor is not None:
+            for key, value in cursor.values.items():
+                if key not in merged and value != "inherit":
+                    if value is not None:
+                        merged[key] = value
+            cursor = cursor.parent
+        return merged

--- a/src/paperops/slides/style/selector.py
+++ b/src/paperops/slides/style/selector.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from paperops.slides.ir.node import Node
+
+_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]*$")
+
+
+@dataclass(frozen=True)
+class PseudoClass:
+    name: str
+    argument: int | None = None
+
+
+@dataclass(frozen=True)
+class SimpleSelector:
+    tag: str | None
+    id: str | None
+    classes: tuple[str, ...]
+    pseudos: tuple[PseudoClass, ...]
+    universal: bool = False
+
+
+@dataclass(frozen=True)
+class ParsedSelector:
+    """A parsed selector in left-to-right order."""
+
+    steps: tuple[SimpleSelector, ...]
+    combinators: tuple[str, ...]
+
+
+def parse_selector(selector: str) -> ParsedSelector:
+    """Parse a CSS-subset selector string.
+
+    Supported:
+      - tag selectors: `card`
+      - class selectors: `.kpi`
+      - id selectors: `#hero`
+      - combinations: `.card.kpi`
+      - descendant: `.card .value`
+      - child: `.card > .value`
+      - wildcard: `*`
+      - pseudo: :first, :last, :only, :nth(N)
+    """
+
+    if not isinstance(selector, str) or not selector.strip():
+        raise ValueError("Selector must be a non-empty string")
+    text = _normalize_selector(selector)
+    tokens = [token for token in text.split() if token]
+    if not tokens:
+        raise ValueError(f"Invalid selector: {selector!r}")
+
+    steps: list[SimpleSelector] = []
+    combinators: list[str] = []
+    next_combinator = "descendant"
+
+    for token in tokens:
+        if token == ">":
+            if not steps:
+                raise ValueError(f"Selector cannot start with child combinator: {selector!r}")
+            if combinators and combinators[-1] == "child":
+                raise ValueError(f"Consecutive '>' combinators: {selector!r}")
+            next_combinator = "child"
+            continue
+
+        step = _parse_simple(token, source=selector)
+        steps.append(step)
+        if len(steps) > 1:
+            combinators.append(next_combinator)
+            next_combinator = "descendant"
+        elif combinators:
+            # Defensive; should never happen because first step has no left relation.
+            raise ValueError(f"Unexpected selector state for: {selector!r}")
+
+    if steps and (combinators and len(combinators) != len(steps) - 1):
+        raise ValueError(f"Invalid selector tokenization: {selector!r}")
+    return ParsedSelector(steps=tuple(steps), combinators=tuple(combinators))
+
+
+def specificity(selector: ParsedSelector | str) -> int:
+    """Compute selector specificity with weights used in issue #2.
+
+    id=100, class/pseudo=10, tag=1.
+    """
+
+    parsed = selector if isinstance(selector, ParsedSelector) else parse_selector(selector)
+    ids = 0
+    tags = 0
+    classes_pseudos = 0
+    for step in parsed.steps:
+        if not step.universal and step.tag:
+            tags += 1
+        if step.id:
+            ids += 1
+        classes_pseudos += len(step.classes)
+        classes_pseudos += sum(1 for pseudo in step.pseudos)
+    return ids * 100 + classes_pseudos * 10 + tags * 1
+
+
+def matches_selector(
+    selector: ParsedSelector,
+    node: Node | dict[str, Any],
+    ancestors: tuple[Node | dict[str, Any], ...],
+    sibling_meta: tuple[tuple[int, int] | None, ...],
+) -> bool:
+    """Return whether `node` is matched by `selector`.
+
+    `ancestors` is root->parent. `sibling_meta` stores, for each node in
+    ancestors plus the current node, the 1-based same-type index and total count.
+    """
+
+    if not selector.steps:
+        return False
+    if len(sibling_meta) != len(ancestors) + 1:
+        raise ValueError("sibling_meta length must be len(ancestors) + 1")
+
+    current_depth = len(ancestors)
+    for right_step in range(len(selector.steps) - 1, -1, -1):
+        current_meta = sibling_meta[current_depth]
+        current_node = _get_node_by_depth(node, ancestors, current_depth)
+        if current_node is None:
+            return False
+        if not _matches_simple(selector.steps[right_step], current_node, current_meta):
+            return False
+
+        if right_step == 0:
+            return True
+
+        relation = selector.combinators[right_step - 1]
+        if relation == "child":
+            if current_depth == 0:
+                return False
+            current_depth -= 1
+        elif relation == "descendant":
+            found = False
+            for candidate_depth in range(current_depth - 1, -1, -1):
+                candidate = _get_node_by_depth(node, ancestors, candidate_depth)
+                candidate_meta = sibling_meta[candidate_depth]
+                if candidate is None or candidate_meta is None:
+                    continue
+                if _matches_simple(
+                    selector.steps[right_step - 1], candidate, candidate_meta
+                ):
+                    current_depth = candidate_depth
+                    found = True
+                    break
+            if not found:
+                return False
+        else:
+            raise ValueError(f"Unknown combinator: {relation}")
+    return False
+
+
+def _normalize_selector(selector: str) -> str:
+    with_spaces = []
+    for char in selector:
+        if char == ">":
+            with_spaces.append(" > ")
+        else:
+            with_spaces.append(char)
+    return "".join(with_spaces).strip()
+
+
+def _parse_simple(selector: str, source: str) -> SimpleSelector:
+    idx = 0
+    n = len(selector)
+    tag: str | None = None
+    selector_id: str | None = None
+    classes: list[str] = []
+    pseudos: list[PseudoClass] = []
+    universal = False
+
+    def read_name(start: int) -> tuple[str, int]:
+        end = start
+        while end < n and _is_name_char(selector[end]):
+            end += 1
+        value = selector[start:end]
+        if not value or not _NAME_RE.match(value):
+            raise ValueError(f"Invalid selector token {value!r} in {source!r}")
+        return value, end
+
+    if idx < n and selector[idx] == "*":
+        universal = True
+        idx += 1
+        if idx < n and _is_name_char(selector[idx]):
+            raise ValueError(f"Unexpected token after '*': {source!r}")
+    elif idx < n and _is_name_char(selector[idx]):
+        tag, idx = read_name(idx)
+
+    while idx < n:
+        char = selector[idx]
+        if char == ".":
+            name, idx = read_name(idx + 1)
+            classes.append(name)
+        elif char == "#":
+            if selector_id is not None:
+                raise ValueError(f"Only one id selector is supported: {source!r}")
+            selector_id, idx = read_name(idx + 1)
+        elif char == ":":
+            pseudo, idx = _read_pseudo(selector, idx, source)
+            pseudos.append(pseudo)
+        else:
+            raise ValueError(f"Unexpected char {char!r} in selector {source!r}")
+
+    if not universal and tag is None and selector_id is None and not classes and not pseudos:
+        raise ValueError(f"Empty selector component in {source!r}")
+    return SimpleSelector(
+        tag=tag,
+        id=selector_id,
+        classes=tuple(classes),
+        pseudos=tuple(pseudos),
+        universal=universal,
+    )
+
+
+def _read_pseudo(selector: str, start: int, source: str) -> tuple[PseudoClass, int]:
+    if selector.startswith(":first", start):
+        return PseudoClass(name="first"), start + len(":first")
+    if selector.startswith(":last", start):
+        return PseudoClass(name="last"), start + len(":last")
+    if selector.startswith(":only", start):
+        return PseudoClass(name="only"), start + len(":only")
+    if not selector.startswith(":nth(", start):
+        raise ValueError(f"Unsupported pseudo in selector {source!r}: ...")
+    close = selector.find(")", start)
+    if close == -1:
+        raise ValueError(f"Unclosed :nth(...) in selector {source!r}")
+    arg = selector[start + 5 : close].strip()
+    if not arg.isdigit():
+        raise ValueError(f"Invalid :nth() value in selector {source!r}")
+    return PseudoClass(name="nth", argument=int(arg)), close + 1
+
+
+def _is_name_char(ch: str) -> bool:
+    return ch.isalnum() or ch in {"_", "-"}
+
+
+def _get_node_by_depth(
+    node: Node | dict[str, Any],
+    ancestors: tuple[Node | dict[str, Any], ...],
+    depth: int,
+) -> Node | dict[str, Any] | None:
+    if depth == len(ancestors):
+        return node
+    if 0 <= depth < len(ancestors):
+        return ancestors[depth]
+    return None
+
+
+def _get_node_type(node: Node | dict[str, Any]) -> str:
+    if isinstance(node, Node):
+        return node.type
+    return str(node["type"])
+
+
+def _get_node_id(node: Node | dict[str, Any]) -> str | None:
+    if isinstance(node, Node):
+        return node.id
+    return node.get("id")
+
+
+def _get_node_classes(node: Node | dict[str, Any]) -> tuple[str, ...]:
+    if isinstance(node, Node):
+        classes = node.class_
+    else:
+        classes = node.get("class", "")
+    if not classes:
+        return ()
+    return tuple(cls for cls in str(classes).split() if cls)
+
+
+def _matches_simple(
+    simple: SimpleSelector,
+    node: Node | dict[str, Any],
+    sibling_meta: tuple[int, int] | None,
+) -> bool:
+    if not simple.universal and simple.tag is not None:
+        if _get_node_type(node) != simple.tag:
+            return False
+    if simple.id is not None:
+        if _get_node_id(node) != simple.id:
+            return False
+
+    node_classes = set(_get_node_classes(node))
+    if any(cls not in node_classes for cls in simple.classes):
+        return False
+    return _matches_pseudos(simple.pseudos, sibling_meta)
+
+
+def _matches_pseudos(
+    pseudos: tuple[PseudoClass, ...], sibling_meta: tuple[int, int] | None
+) -> bool:
+    if not pseudos:
+        return True
+    if sibling_meta is None:
+        return False
+    position, total = sibling_meta
+    for pseudo in pseudos:
+        if pseudo.name == "first":
+            if position != 1:
+                return False
+        elif pseudo.name == "last":
+            if position != total:
+                return False
+        elif pseudo.name == "only":
+            if total != 1:
+                return False
+        elif pseudo.name == "nth":
+            if pseudo.argument != position:
+                return False
+        else:
+            return False
+    return True

--- a/src/paperops/slides/style/stylesheet.py
+++ b/src/paperops/slides/style/stylesheet.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Iterator, Mapping
+
+from paperops.slides.style.selector import ParsedSelector, parse_selector, specificity
+
+
+@dataclass(frozen=True)
+class StyleRule:
+    selector_text: str
+    selector: ParsedSelector
+    declarations: Mapping[str, Any]
+    source_index: int
+
+    @property
+    def specificity(self) -> int:
+        return specificity(self.selector)
+
+
+class StyleSheet:
+    """Ordered selector -> declaration map."""
+
+    def __init__(self, rules: Mapping[str, Mapping[str, Any]] | None = None):
+        self._rules: list[StyleRule] = []
+        if rules:
+            for index, (selector_text, declarations) in enumerate(rules.items()):
+                self._append_rule(selector_text, declarations, source_index=index)
+
+    def _append_rule(
+        self,
+        selector_text: str,
+        declarations: Mapping[str, Any],
+        source_index: int,
+    ) -> None:
+        if not isinstance(declarations, Mapping):
+            raise TypeError(
+                f"Style declarations for {selector_text!r} must be a mapping"
+            )
+        parsed = parse_selector(selector_text)
+        self._rules.append(
+            StyleRule(
+                selector_text=selector_text,
+                selector=parsed,
+                declarations=dict(declarations),
+                source_index=source_index,
+            )
+        )
+
+    def __len__(self) -> int:
+        return len(self._rules)
+
+    def __iter__(self) -> Iterator[StyleRule]:
+        return iter(self._rules)
+
+    def __getitem__(self, selector_text: str) -> dict[str, Any]:
+        for rule in self._rules:
+            if rule.selector_text == selector_text:
+                return dict(rule.declarations)
+        raise KeyError(selector_text)
+
+    def items(self) -> Iterator[tuple[str, Mapping[str, Any]]]:
+        for rule in self._rules:
+            yield rule.selector_text, rule.declarations

--- a/tests/style/test_cascade.py
+++ b/tests/style/test_cascade.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import time
+
+from paperops.slides.core import themes
+from paperops.slides.ir.node import Node
+from paperops.slides.style import CascadeResult, StyleSheet, resolve_computed_styles
+
+
+def _style(result: CascadeResult, node: Node):
+    return result.style_for(node)
+
+
+def test_sheet_selector_precedence_resolves_card_kpi_bg():
+    sheet = StyleSheet(
+        {
+            ".card": {"bg": "bg_alt"},
+            ".card.kpi": {"bg": "bg_accent"},
+        }
+    )
+    node = Node(type="card", class_="card kpi")
+    result = resolve_computed_styles(
+        node,
+        theme=themes.minimal,
+        style_sheet=sheet,
+    )
+    assert _style(result, node).get("bg") == themes.minimal.colors["bg_accent"]
+
+
+def test_descendant_selector_only_targets_descendants():
+    deck = Node(
+        type="deck",
+        class_="deck",
+        children=[
+            Node(type="card", class_="card", children=[Node(type="value", class_="value")]),
+            Node(type="value", class_="value"),
+        ],
+    )
+    sheet = StyleSheet({".card .value": {"color": "primary"}})
+    result = resolve_computed_styles(deck, theme=themes.minimal, style_sheet=sheet, strict=False)
+    direct_child_value = deck.children[0].children[0]
+    root_value = deck.children[1]
+    assert direct_child_value is not None and isinstance(direct_child_value, Node)
+    assert root_value is not None and isinstance(root_value, Node)
+    assert _style(result, direct_child_value).get("color") == themes.minimal.colors["primary"]
+    assert _style(result, root_value).get("color") is None
+
+
+def test_child_selector_only_targets_direct_children():
+    deck = Node(
+        type="deck",
+        children=[
+            Node(
+                type="card",
+                class_="card",
+                children=[Node(type="value", class_="value")],
+            ),
+            Node(type="value", class_="value"),
+            Node(
+                type="card",
+                children=[
+                    Node(type="value", class_="value", children=[]),
+                ],
+            ),
+        ],
+    )
+    sheet = StyleSheet({".card > .value": {"bg": "bg_accent"}})
+    result = resolve_computed_styles(deck, theme=themes.minimal, style_sheet=sheet, strict=False)
+    direct = deck.children[0].children[0]
+    grandchild = deck.children[2].children[0]
+    loose = deck.children[1]
+    assert _style(result, direct).get("bg") == themes.minimal.colors["bg_accent"]
+    assert _style(result, grandchild).get("bg") is None
+    assert _style(result, loose).get("bg") is None
+
+
+def test_pseudo_first_matches_only_first_same_type_node():
+    container = Node(
+        type="stack",
+        children=[
+            Node(type="value", class_="value"),
+            Node(type="text"),
+            Node(type="value", class_="value"),
+            Node(type="value", class_="value"),
+        ],
+    )
+    sheet = StyleSheet({".value:first": {"color": "negative"}})
+    result = resolve_computed_styles(container, theme=themes.academic, style_sheet=sheet, strict=False)
+    first = container.children[0]
+    second = container.children[2]
+    third = container.children[3]
+    assert isinstance(first, Node)
+    assert isinstance(second, Node)
+    assert isinstance(third, Node)
+    assert _style(result, first).get("color") == themes.academic.colors["negative"]
+    assert _style(result, second).get("color") is None
+    assert _style(result, third).get("color") is None
+
+
+def test_same_specificity_later_rule_wins():
+    sheet = StyleSheet(
+        {
+            ".kpi": {"bg": "bg_alt"},
+            ".highlight": {"bg": "bg_accent"},
+        }
+    )
+    node = Node(type="value", class_="kpi highlight")
+    result = resolve_computed_styles(node, theme=themes.minimal, style_sheet=sheet)
+    assert _style(result, node).get("bg") == themes.minimal.colors["bg_accent"]
+
+
+def test_inline_style_overrides_sheet_even_high_specificity():
+    sheet = StyleSheet({".value": {"bg": "bg_alt", "font": "title"}})
+    node = Node(type="value", class_="value", style={"bg": "bg_accent", "font": "body"})
+    result = resolve_computed_styles(node, theme=themes.minimal, style_sheet=sheet)
+    assert _style(result, node).get("bg") == themes.minimal.colors["bg_accent"]
+    assert _style(result, node).get("font") == themes.minimal.fonts["body"]
+
+
+def test_inherited_style_key_flows_down_until_overridden():
+    tree = Node(
+        type="deck",
+        children=[
+            Node(type="card", style={"color": "primary"}, children=[
+                Node(type="value", children=[])
+            ])
+        ],
+    )
+    result = resolve_computed_styles(tree, theme=themes.academic, strict=False)
+    card = tree.children[0]
+    value = card.children[0]
+    assert isinstance(card, Node)
+    assert isinstance(value, Node)
+    assert _style(result, card).get("color") == themes.academic.colors["primary"]
+    assert _style(result, value).get("color") == themes.academic.colors["primary"]
+
+    override = Node(
+        type="deck",
+        children=[
+            Node(type="card", style={"color": "positive"}, children=[
+                Node(type="value", class_="value")
+            ]),
+        ],
+    )
+    resolved_override = resolve_computed_styles(override, theme=themes.academic, strict=False)
+    overridden_value = override.children[0].children[0]
+    assert _style(resolved_override, overridden_value).get("color") == themes.academic.colors["positive"]
+
+
+def test_non_inheritable_style_key_does_not_inherit():
+    tree = Node(type="deck", style={"bg": "bg_alt"}, children=[
+        Node(type="card")
+    ])
+    result = resolve_computed_styles(tree, theme=themes.minimal, strict=False)
+    child = tree.children[0]
+    assert isinstance(child, Node)
+    assert _style(result, child).get("bg") is None
+
+
+def test_blacklist_style_key_reports_structured_error():
+    node = Node(type="card", style={"display": "flex"})
+    result = resolve_computed_styles(node, theme=themes.minimal, strict=False)
+    assert result.errors
+    error = result.errors[0]
+    assert error.code == "UNKNOWN_STYLE_KEY"
+    assert error.key == "display"
+    assert error.suggestion and "<Flex>" in error.suggestion
+
+
+def test_pseudo_nth_matches_position():
+    container = Node(
+        type="stack",
+        children=[
+            Node(type="item", class_="value"),
+            Node(type="item", class_="value"),
+            Node(type="item", class_="value"),
+        ],
+    )
+    sheet = StyleSheet({".value:nth(2)": {"color": "positive"}})
+    result = resolve_computed_styles(container, theme=themes.academic, style_sheet=sheet, strict=False)
+    middle = container.children[1]
+    assert isinstance(middle, Node)
+    assert _style(result, middle).get("color") == themes.academic.colors["positive"]
+
+
+def test_computed_style_lookup_follows_fallback_chain():
+    tree = Node(type="deck", style={"color": "primary"}, children=[
+        Node(type="card", children=[Node(type="value", style={})])
+    ])
+    result = resolve_computed_styles(tree, theme=themes.academic, strict=False)
+    value = tree.children[0].children[0]
+    assert isinstance(value, Node)
+    assert _style(result, value).get("color") == themes.academic.colors["primary"]
+
+
+def test_style_resolution_is_fast_for_thousands_of_nodes():
+    sheet = StyleSheet({f".c{i}": {"font": "body", "padding": "md"} for i in range(20)})
+    slides = []
+    for _ in range(20):
+        children = [
+            Node(type="item", class_=f"c{i % 20}") for i in range(150)
+        ]
+        slides.append(Node(type="slide", children=children))
+    deck = Node(type="deck", children=slides)
+
+    start = time.perf_counter()
+    result = resolve_computed_styles(
+        deck,
+        theme=themes.minimal,
+        style_sheet=sheet,
+        strict=False,
+    )
+    elapsed = time.perf_counter() - start
+
+    assert isinstance(result, CascadeResult)
+    assert len(result.computed) == 1 + 20 + 3000
+    assert elapsed < 0.2
+
+
+def test_theme_default_sheet_deck_local_and_inline_precedence():
+    node = Node(type="value", class_="value", style={"font": "title"})
+    result = resolve_computed_styles(
+        node,
+        theme=themes.minimal,
+        theme_defaults={"value": {"font": "body"}},
+        style_sheet=StyleSheet({".value": {"font": "caption"}},
+        ),
+        deck_style=StyleSheet({".value": {"font": "primary"}}),
+        strict=False,
+    )
+    assert _style(result, node).get("font") == themes.minimal.fonts["title"]
+
+
+def test_inherit_value_for_inheritable_key_keeps_chain():
+    tree = Node(type="deck", style={"color": "primary"}, children=[Node(type="value", style={"color": "inherit"})])
+    result = resolve_computed_styles(tree, theme=themes.academic, strict=False)
+    child = tree.children[0]
+    assert isinstance(child, Node)
+    assert _style(result, child).get("color") == themes.academic.colors["primary"]
+
+
+def test_auto_and_none_values_are_preserved():
+    node = Node(type="value", style={"color": "auto", "bg": "none"})
+    result = resolve_computed_styles(node, theme=themes.minimal, strict=False)
+    assert _style(result, node).get("color") == "auto"
+    assert _style(result, node).get("bg") == "none"

--- a/tests/style/test_selector.py
+++ b/tests/style/test_selector.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+from paperops.slides.ir.node import Node
+from paperops.slides.style.selector import parse_selector, specificity
+
+
+def test_parse_and_specificity_supports_combinations():
+    parsed = parse_selector(".card.kpi.primary")
+    assert len(parsed.steps) == 1
+    assert specificity(parsed) == 30
+
+
+def test_parse_accepts_descendant_and_child_operators():
+    descendant = parse_selector(".card .value")
+    child = parse_selector(".card > .value")
+    assert descendant.combinators == ("descendant",)
+    assert child.combinators == ("child",)
+
+
+def test_specificity_weights_id_class_tag():
+    assert specificity(parse_selector("#hero")) == 100
+    assert specificity(parse_selector(".a")) == 10
+    assert specificity(parse_selector("title")) == 1
+
+
+def test_selector_rejects_unsupported_token():
+    with pytest.raises(ValueError):
+        parse_selector("a[role=btn]")


### PR DESCRIPTION
## Summary
Implemented Phase 1 style resolution engine for slide DSL:

- Added selector parser and matcher (`tag`, `.class`, `#id`, `.a.b`, `tag.class`, descendant, child, wildcard, and pseudo classes `:first/:last/:only/:nth(N)`)
- Added ordered `StyleSheet` data model with selector pre-parsing
- Added specificity model (id=100, class/pseudo=10, tag=1)
- Added cascade resolver with source precedence: theme defaults -> sheet -> deck-local -> inline
- Added inheritance (with explicit inherit/auto/none handling) and non-inheritable filter
- Added `ComputedStyle` lookup with fallback for inheritable keys
- Added blacklist validation and `UNKNOWN_STYLE_KEY` error reporting
- Added unit tests covering acceptance criteria and performance baseline

## Files
- `src/paperops/slides/style/__init__.py`
- `src/paperops/slides/style/computed.py`
- `src/paperops/slides/style/selector.py`
- `src/paperops/slides/style/stylesheet.py`
- `src/paperops/slides/style/cascade.py`
- `tests/style/test_selector.py`
- `tests/style/test_cascade.py`

## Validation
- `tests/style/test_selector.py`
- `tests/style/test_cascade.py`

Closes #2.