### PR TITLE
Phase 3: registry components, semantic components, and atomic sheet variant coverage

### DIFF
--- a/docs/components_api.md
+++ b/docs/components_api.md
@@ -1,0 +1,43 @@
+# Component API (Phase 3)
+
+## Atomic Components
+
+| Component | Default class | Props | Example |
+|---|---|---|---|
+| `text` | `text` | `text` | `{"type":"text","text":"Hello"}` |
+| `prose` | `prose` | `text` | `{"type":"prose","text":"A short paragraph."}` |
+| `title` | `title` | `text` | `{"type":"title","text":"Annual Report"}` |
+| `subtitle` | `subtitle` | `text` | `{"type":"subtitle","text":"Q2 Update"}` |
+| `heading` | `heading` | `text` | `{"type":"heading","text":"Highlights"}` |
+| `box` | `box` | `text`, `style` | `{"type":"box","text":"Panel text"}` |
+| `roundedbox` | `rounded-box` | `text` | `{"type":"roundedbox","text":"Chip"}` |
+| `circle` | `circle` | `text` | `{"type":"circle","text":"1"}` |
+| `badge` | `badge` | `text` | `{"type":"badge","text":"New"}` |
+| `line` | `line` | `from`, `to`, `style`, `color`, `weight` | `{"type":"line","text":"divider"}` |
+| `arrow` | `arrow` | `from`, `to`, `head`, `color`, `weight` | `{"type":"arrow","text":"Flow"}` |
+| `divider` | `divider` | `orientation`, `thickness`, `length` | `{"type":"divider","props":{"orientation":"horizontal"}}` |
+| `image` | `image` | `src`, `fit`, `width`, `height`, `alt` | `{"type":"image","props":{"src":"path/to/file.png"}}` |
+| `svg` | `svg` | `src`, `body`, `fit`, `width`, `height` | `{"type":"svg","props":{"body":"<svg/>"}}` |
+| `icon` | `icon` | `name`, `size`, `color` | `{"type":"icon","props":{"name":"star","size":"lg"}}` |
+| `chart` | `chart` | `chart_type`, `data`, `title`, `labels`, `series`, `width`, `height` | `{"type":"chart","props":{"chart_type":"line"}}` |
+| `table` | `table` | `headers`, `rows`, `header_color`, `header_text_color`, `font_size`, `row_height` | `{"type":"table","props":{"headers":["A","B"],"rows":[["1","2"]]}}` |
+| `spacer` | `spacer` | `size`, `orientation`, `width`, `height` | `{"type":"spacer","props":{"size":"lg"}}` |
+
+## Semantic Components
+
+| Component | Default class | Props (required) | Example |
+|---|---|---|---|
+| `card` | `card` | *(none)* | `{"type":"card","children":[{"type":"text","text":"panel"}]}` |
+| `kpi` | `kpi` | `label`, `value` / `delta` | `{"type":"kpi","props":{"label":"DAU","value":"125k","delta":"+56%"}}` |
+| `callout` | `callout` | `kind`, `text` | `{"type":"callout","props":{"kind":"Insight","text":"A key observation"}}` |
+| `quote` | `quote` | `text` / `author` | `{"type":"quote","props":{"text":"Data changes fast","author":"Ops Team"}}` |
+| `pullquote` | `pullquote` | `text` / `author` | `{"type":"pullquote","props":{"text":"Important takeaway"}}` |
+| `keypoint` | `keypoint` | `number`, `title`, `body` | `{"type":"keypoint","props":{"number":"01","title":"Setup","body":"Collect events"}}` |
+| `stepper` | `stepper` | `steps` | `{"type":"stepper","props":{"steps":[{"label":"Collect"},{"label":"Analyze"},{"label":"Report"}]}}` |
+| `timeline` | `timeline` | `items` | `{"type":"timeline","props":{"items":[{"date":"2026-01","title":"Pilot","desc":"Start"}]}}` |
+| `figure` | `figure` | `src` / `body` / `chart_type`, `caption`, `source` | `{"type":"figure","props":{"chart_type":"bar","caption":"Recovery trend"}}` |
+| `caption` | `caption` | `text` | `{"type":"caption","props":{"text":"Chart source: Internal"}}` |
+| `spacer` | `spacer` | `size`, `orientation`, `width`, `height` | `{"type":"spacer","props":{"size":"lg"}}` |
+
+> `note` is a semantic component in this phase so speaker-only text is captured by
+> `codegen` into PPT speaker notes and does not create a visible shape.

--- a/docs/components_api.md
+++ b/docs/components_api.md
@@ -13,8 +13,8 @@
 | `roundedbox` | `rounded-box` | `text` | `{"type":"roundedbox","text":"Chip"}` |
 | `circle` | `circle` | `text` | `{"type":"circle","text":"1"}` |
 | `badge` | `badge` | `text` | `{"type":"badge","text":"New"}` |
-| `line` | `line` | `from`, `to`, `style`, `color`, `weight` | `{"type":"line","text":"divider"}` |
-| `arrow` | `arrow` | `from`, `to`, `head`, `color`, `weight` | `{"type":"arrow","text":"Flow"}` |
+| `line` | `line` | `from`, `to`, `style`, `color`, `weight` | `{"type":"line","props":{"from":"left","to":"right","weight":1.5}}` |
+| `arrow` | `arrow` | `from`, `to`, `head`, `color`, `weight` | `{"type":"arrow","props":{"from":"left","to":"right","head":"end"}}` |
 | `divider` | `divider` | `orientation`, `thickness`, `length` | `{"type":"divider","props":{"orientation":"horizontal"}}` |
 | `image` | `image` | `src`, `fit`, `width`, `height`, `alt` | `{"type":"image","props":{"src":"path/to/file.png"}}` |
 | `svg` | `svg` | `src`, `body`, `fit`, `width`, `height` | `{"type":"svg","props":{"body":"<svg/>"}}` |

--- a/docs/components_api.md
+++ b/docs/components_api.md
@@ -38,6 +38,7 @@
 | `figure` | `figure` | `src` / `body` / `chart_type`, `caption`, `source` | `{"type":"figure","props":{"chart_type":"bar","caption":"Recovery trend"}}` |
 | `caption` | `caption` | `text` | `{"type":"caption","props":{"text":"Chart source: Internal"}}` |
 | `spacer` | `spacer` | `size`, `orientation`, `width`, `height` | `{"type":"spacer","props":{"size":"lg"}}` |
+| `note` | `note` | *(none)* | `{"type":"note","children":["Speaker note goes here"]}` |
 
-> `note` is a semantic component in this phase so speaker-only text is captured by
-> `codegen` into PPT speaker notes and does not create a visible shape.
+> `note` is a semantic component in this phase, so speaker-only text is captured
+> by `codegen` into PPT speaker notes and does not create a visible shape.

--- a/examples/gallery/gallery_content.json
+++ b/examples/gallery/gallery_content.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "paperops-slide-1.0",
+  "theme": "minimal",
+  "slides": [
+    {
+      "type": "slide",
+      "class": "cover",
+      "children": [
+        { "type": "title", "text": "HKU Talk: AI Diagnosis for Operators" },
+        { "type": "subtitle", "text": "gallery deck for style-sheet variants" }
+      ]
+    },
+    {
+      "type": "slide",
+      "class": "content",
+      "children": [
+        { "type": "heading", "text": "Executive Snapshot" },
+        {
+          "type": "grid",
+          "style": { "cols": "1fr 1fr 1fr", "gap": "lg" },
+          "children": [
+            { "type": "kpi", "props": { "label": "DAU", "value": "125k", "delta": "+56%", "trend": "positive" } },
+            { "type": "kpi", "props": { "label": "Retention", "value": "42%", "delta": "+8p", "trend": "positive" } },
+            { "type": "kpi", "props": { "label": "Churn", "value": "3.2%", "delta": "-1p", "trend": "negative" } }
+          ]
+        },
+        { "type": "callout", "props": { "kind": "Insight", "text": "Core problem: root-cause evidence is delayed in production traces." } }
+      ]
+    },
+    {
+      "type": "slide",
+      "children": [
+        { "type": "heading", "text": "Story & Visual Grammar" },
+        {
+          "type": "quote",
+          "props": {
+            "text": "A good diagnosis loop is not just faster, but more reliable.",
+            "author": "Ops Research Team"
+          }
+        },
+        {
+          "type": "pullquote",
+          "props": {
+            "text": "Data volume alone does not imply scientific rigor.",
+            "author": "Field notes"
+          }
+        },
+        {
+          "type": "keypoint",
+          "props": {
+            "number": "01",
+            "title": "Instrument every boundary",
+            "body": "Capture failures and context consistently."
+          }
+        }
+      ]
+    },
+    {
+      "type": "slide",
+      "children": [
+        { "type": "heading", "text": "Process" },
+        {
+          "type": "stepper",
+          "props": {
+            "steps": [
+            { "label": "Collect traces", "desc": "normalize events & sessions" },
+            { "label": "Infer structure", "desc": "build causal graph candidates" },
+            { "label": "Prioritize actions", "desc": "recommend repair experiment" }
+            ]
+          }
+        },
+        {
+          "type": "timeline",
+          "props": {
+            "items": [
+              { "date": "2026-01", "title": "Pilot", "desc": "1 platform onboarded" },
+              { "date": "2026-02", "title": "Scale", "desc": "3 teams joined" },
+              { "date": "2026-03", "title": "Review", "desc": "confidence improved" }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "slide",
+      "children": [
+        { "type": "heading", "text": "Evidence Pack" },
+        { "type": "card", "children": [{ "type": "text", "text": "Card container proof." }]},
+        {
+          "type": "figure",
+          "props": {
+            "chart_type": "line",
+            "caption": "System recovery trend over rollout windows",
+            "source": "Synthetic source set"
+          }
+        },
+        {
+          "type": "table",
+          "props": {
+            "headers": ["Region", "Pass Rate", "Cost / Test"],
+            "rows": [
+              ["EMEA", "88%", "$124"],
+              ["APAC", "92%", "$108"],
+              ["AMER", "95%", "$93"]
+            ]
+          }
+        },
+        {
+          "type": "chart",
+          "props": {
+            "chart_type": "bar",
+            "title": "Recovery speed",
+            "data": {}
+          }
+        },
+        {
+          "type": "image",
+          "props": {
+            "src": "missing.png",
+            "alt": "ops dashboard placeholder"
+          }
+        },
+        { "type": "text", "text": "Shape primitives" },
+        { "type": "line", "text": "line primitive" },
+        { "type": "arrow", "text": "arrow primitive" },
+        { "type": "badge", "text": "badge" },
+        { "type": "circle", "text": "◉" },
+        { "type": "roundedbox", "text": "rounded box" },
+        { "type": "divider", "props": { "orientation": "horizontal", "thickness": 1 } },
+        { "type": "icon", "props": { "name": "spark", "size": "md", "color": "primary" } },
+        { "type": "spacer", "props": { "size": "lg" } },
+        { "type": "note", "children": ["Use this deck as gallery source for six style sheets."] }
+      ]
+    }
+  ]
+}

--- a/examples/gallery/render_gallery_variants.py
+++ b/examples/gallery/render_gallery_variants.py
@@ -1,0 +1,46 @@
+"""Build the gallery deck under six preset sheets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from paperops.slides.build import render_json
+
+
+ROOT = Path(__file__).resolve().parent
+CONTENT = ROOT / "gallery_content.json"
+SHEETS = ("minimal", "academic", "seminar", "keynote", "whitepaper", "pitch")
+
+
+def _load_content() -> dict:
+    return json.loads(CONTENT.read_text(encoding="utf-8"))
+
+
+def build_gallery(output_dir: Path) -> list[Path]:
+    payload = _load_content()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    results: list[Path] = []
+
+    for sheet in SHEETS:
+        payload["sheet"] = sheet
+        out = output_dir / f"gallery_{sheet}.pptx"
+        results.append(render_json(payload, out=out))
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Render gallery variants")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=ROOT,
+        help="Directory for generated .pptx files",
+    )
+    args = parser.parse_args()
+    build_gallery(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/paperops/slides/build.py
+++ b/src/paperops/slides/build.py
@@ -12,6 +12,7 @@ import tempfile
 from pptx import Presentation as PptxPresentation
 from pptx.util import Inches
 
+from paperops.slides import components  # noqa: F401
 from paperops.slides.codegen import render_styled_layout
 from paperops.slides.core.constants import CONTENT_REGION, SLIDE_HEIGHT, SLIDE_WIDTH
 from paperops.slides.core.theme import Theme, themes

--- a/src/paperops/slides/build.py
+++ b/src/paperops/slides/build.py
@@ -18,7 +18,8 @@ from paperops.slides.core.theme import Theme, themes
 from paperops.slides.dsl.json_loader import Document
 from paperops.slides.dsl.json_loader import load_json_document
 from paperops.slides.layout.engine import build_layout_tree, compute_layout
-from paperops.slides.style import resolve_computed_styles
+from paperops.slides.components.registry import expand_nodes
+from paperops.slides.style import get_sheet, resolve_computed_styles
 from paperops.slides.style.stylesheet import StyleSheet
 from paperops.slides.preview import review_deck_artifacts
 
@@ -54,16 +55,27 @@ def parse_stage(
     return load_json_document(source, strict=strict)
 
 
+def expand_stage(document: Document, *, strict: bool = False) -> list[Node]:
+    """Expand semantic components and return expanded slide roots."""
+    return expand_nodes(document.slides, strict=strict)
+
+
 def style_stage(
     document: Document,
     *,
     theme: Theme | str | None = None,
-    sheet: Mapping[str, Mapping[str, Any]] | None = None,
+    sheet: Mapping[str, Mapping[str, Any]] | str | None = None,
     strict: bool = False,
 ) -> tuple[Node, dict[int, Any]]:
     """Resolve computed styles and attach them to every styled node."""
+    if sheet is None and document.sheet is not None:
+        sheet = document.sheet
+    if isinstance(sheet, str):
+        sheet = get_sheet(sheet)
+
     style_theme = _coerce_theme(theme or document.theme)
-    root = Node(type="deck", children=list(document.slides))
+    expanded_slides = expand_stage(document, strict=strict)
+    root = Node(type="deck", children=expanded_slides)
     resolved = resolve_computed_styles(
         root,
         theme=style_theme,

--- a/src/paperops/slides/codegen/pptx_backend.py
+++ b/src/paperops/slides/codegen/pptx_backend.py
@@ -166,10 +166,10 @@ def _render_leaf(
     text = _extract_text(source_node, layout_node)
     node_type = source_node.type if source_node is not None else None
     style = _style_snapshot(source_node)
-    left = Inches(float(region.left))
-    top = Inches(float(region.top))
-    width = Inches(float(region.width))
-    height = Inches(float(region.height))
+    left = float(region.left)
+    top = float(region.top)
+    width = float(region.width)
+    height = float(region.height)
 
     if node_type in {"box", "kpi"} or isinstance(layout_node, ShapeBox):
         _render_box(
@@ -180,6 +180,63 @@ def _render_leaf(
             text=text,
         )
         return
+    if node_type == "roundedbox" and not isinstance(layout_node, ShapeBox):
+        _render_rounded_box(
+            slide=slide,
+            region=(left, top, width, height),
+            style=style,
+            theme=theme,
+            text=text,
+        )
+        return
+    if node_type == "circle":
+        _render_circle(
+            slide=slide,
+            region=(left, top, width, height),
+            style=style,
+            theme=theme,
+            text=text,
+        )
+        return
+    if node_type == "badge":
+        _render_badge(
+            slide=slide,
+            region=(left, top, width, height),
+            style=style,
+            theme=theme,
+            text=text,
+        )
+        return
+    if node_type == "divider":
+        _render_divider(
+            slide=slide,
+            region=(left, top, width, height),
+            style=style,
+            theme=theme,
+            text=text,
+        )
+        return
+    if node_type == "line":
+        _render_connector(
+            slide=slide,
+            region=(left, top, width, height),
+            style=style,
+            theme=theme,
+            node_type="line",
+        )
+        return
+    if node_type == "arrow":
+        _render_connector(
+            slide=slide,
+            region=(left, top, width, height),
+            style=style,
+            theme=theme,
+            node_type="arrow",
+        )
+        return
+    if node_type in {"image", "svg", "icon"}:
+        if _render_image_like(slide, node_type, source_node, style, theme, (left, top, width, height), text):
+            return
 
     if _is_textual_node(node_type) or text:
         _render_text_box(
@@ -217,7 +274,7 @@ def _text_color(style: dict[str, Any], theme: Theme) -> RGBColor:
 def _render_box(
     *,
     slide,
-    region: tuple,
+    region: tuple[float, float, float, float],
     style: dict[str, Any],
     theme: Theme,
     text: str,
@@ -225,10 +282,10 @@ def _render_box(
     left, top, width, height = region
     shape = slide.shapes.add_shape(
         MSO_SHAPE.RECTANGLE,
-        left,
-        top,
-        width,
-        height,
+        Inches(left),
+        Inches(top),
+        Inches(width),
+        Inches(height),
     )
 
     fill = shape.fill
@@ -242,7 +299,8 @@ def _render_box(
             theme,
             _style_value(style, "border", _theme_default_color(theme, "border")),
         )
-        shape.line.width = Pt(_to_float(_style_value(style, "line-width", 1.0)))
+        line_width = _to_float(_style_value(style, "line-width", 1.0))
+        shape.line.width = Pt(line_width if line_width is not None else 1.0)
     else:
         shape.line.fill.background()
 
@@ -260,6 +318,268 @@ def _theme_default_color(theme: Theme, key: str) -> str:
     return str(theme.colors.get(key, "#FFFFFF"))
 
 
+def _render_rounded_box(
+    *,
+    slide,
+    region: tuple[float, float, float, float],
+    style: dict[str, Any],
+    theme: Theme,
+    text: str,
+) -> None:
+    left, top, width, height = region
+    shape = slide.shapes.add_shape(
+        MSO_SHAPE.ROUNDED_RECTANGLE,
+        Inches(left),
+        Inches(top),
+        Inches(width),
+        Inches(height),
+    )
+
+    fill = shape.fill
+    fill.solid()
+    fill.fore_color.rgb = _resolve_color(
+        theme, _style_value(style, "bg", _theme_default_color(theme, "bg_alt"))
+    )
+
+    shape.line.fill.background()
+    if _style_value(style, "border", "none") not in {"none", None, "inherit"}:
+        shape.line.color.rgb = _resolve_color(
+            theme,
+            _style_value(style, "border", _theme_default_color(theme, "border")),
+        )
+        line_width = _to_float(_style_value(style, "line-width", 1.0))
+        shape.line.width = Pt(line_width if line_width is not None else 1.0)
+
+    if text:
+        tf = shape.text_frame
+        _apply_text_frame_style(tf, style, theme=theme)
+        paragraph = tf.paragraphs[0]
+        paragraph.text = text
+        paragraph.alignment = _ALIGN_MAP.get(
+            _style_value(style, "text-align", "center"), PP_ALIGN.LEFT
+        )
+
+
+def _render_circle(
+    *,
+    slide,
+    region: tuple[float, float, float, float],
+    style: dict[str, Any],
+    theme: Theme,
+    text: str,
+) -> None:
+    left, top, width, height = region
+    diameter = max(width, height)
+    cx = left + (width - diameter) / 2.0
+    cy = top + (height - diameter) / 2.0
+    shape = slide.shapes.add_shape(
+        MSO_SHAPE.OVAL,
+        Inches(cx),
+        Inches(cy),
+        Inches(diameter),
+        Inches(diameter),
+    )
+
+    fill = shape.fill
+    fill.solid()
+    fill.fore_color.rgb = _resolve_color(
+        theme, _style_value(style, "bg", _theme_default_color(theme, "primary"))
+    )
+    shape.line.fill.background()
+
+    if text:
+        tf = shape.text_frame
+        _apply_text_frame_style(tf, style, theme=theme)
+        paragraph = tf.paragraphs[0]
+        paragraph.text = text
+        paragraph.alignment = PP_ALIGN.CENTER
+
+
+def _render_badge(
+    *,
+    slide,
+    region: tuple[float, float, float, float],
+    style: dict[str, Any],
+    theme: Theme,
+    text: str,
+) -> None:
+    left, top, width, height = region
+    shape = slide.shapes.add_shape(
+        MSO_SHAPE.ROUNDED_RECTANGLE,
+        Inches(left),
+        Inches(top),
+        Inches(width),
+        Inches(height),
+    )
+    fill = shape.fill
+    fill.solid()
+    fill.fore_color.rgb = _resolve_color(
+        theme, _style_value(style, "bg", _theme_default_color(theme, "accent"))
+    )
+    shape.line.fill.background()
+
+    if text:
+        tf = shape.text_frame
+        _apply_text_frame_style(tf, style, theme=theme)
+        paragraph = tf.paragraphs[0]
+        paragraph.text = text
+        paragraph.alignment = PP_ALIGN.CENTER
+
+
+def _render_divider(
+    *,
+    slide,
+    region: tuple[float, float, float, float],
+    style: dict[str, Any],
+    theme: Theme,
+    text: str,
+)-> None:
+    style_orientation = _style_value(style, "orientation", _style_value(style, "direction", "horizontal"))
+    is_vertical = str(style_orientation).lower() in {"vertical", "v"}
+
+    left, top, width, height = region
+    if is_vertical:
+        x1 = Inches(left + width / 2.0)
+        y1 = Inches(top)
+        x2 = Inches(left + width / 2.0)
+        y2 = Inches(top + height)
+    else:
+        x1 = Inches(left)
+        y1 = Inches(top + height / 2.0)
+        x2 = Inches(left + width)
+        y2 = Inches(top + height / 2.0)
+
+    shape = slide.shapes.add_connector(1, x1, y1, x2, y2)
+    shape.line.color.rgb = _resolve_color(
+        theme, _style_value(style, "color", _theme_default_color(theme, "border"))
+    )
+    line_width = _to_float(_style_value(style, "line-width", 1.0))
+    shape.line.width = Pt(line_width if line_width is not None else 1.0)
+
+
+def _render_connector(
+    *,
+    slide,
+    region: tuple[float, float, float, float],
+    style: dict[str, Any],
+    theme: Theme,
+    node_type: str,
+) -> None:
+    left, top, width, height = region
+    is_vertical = str(_style_value(style, "orientation", "horizontal")).lower() in {"vertical", "v"}
+
+    x1 = left + 0.0
+    y1 = top + height / 2.0
+    x2 = left + width
+    y2 = top + height / 2.0
+    if is_vertical:
+        x1 = left + width / 2.0
+        y1 = top
+        x2 = left + width / 2.0
+        y2 = top + height
+
+    connector = slide.shapes.add_connector(1, Inches(x1), Inches(y1), Inches(x2), Inches(y2))
+    connector.line.color.rgb = _resolve_color(
+        theme, _style_value(style, "color", _theme_default_color(theme, "border"))
+    )
+    line_width = _to_float(_style_value(style, "line-width", 1.0))
+    connector.line.width = Pt(line_width if line_width is not None else 1.0)
+
+    if node_type == "arrow" and width > 0.0 and height > 0.0:
+        line_color = _resolve_color(
+            theme, _style_value(style, "color", _theme_default_color(theme, "border"))
+        )
+        connector.line.color.rgb = line_color
+        from pptx.oxml.ns import qn
+
+        line_element = connector.line._ln
+        arrow_tip = line_element.makeelement(qn("a:headEnd"), {})
+        arrow_tip.set("type", "triangle")
+        arrow_tip.set("w", "med")
+        arrow_tip.set("len", "med")
+        line_element.append(arrow_tip)
+
+
+def _render_image_like(
+    slide,
+    node_type: str,
+    source_node: Node | None,
+    style: dict[str, Any],
+    theme: Theme,
+    region: tuple[float, float, float, float],
+    extracted_text: str,
+) -> bool:
+    props = source_node.props if source_node is not None else {}
+    left, top, width, height = region
+    if node_type == "icon":
+        text = props.get("name")
+        if text:
+            _render_text_box(
+                slide=slide,
+                region=(left, top, width, height),
+                node=source_node,
+                style=style,
+                theme=theme,
+                text=f"[icon] {text}",
+            )
+            return True
+        if extracted_text:
+            _render_text_box(
+                slide=slide,
+                region=(left, top, width, height),
+                node=source_node,
+                style=style,
+                theme=theme,
+                text=extracted_text,
+            )
+            return True
+        return False
+
+    src = ""
+    if isinstance(props, dict):
+        src = str(props.get("src", "") or "")
+
+    if node_type == "svg" and not src:
+        src = str(props.get("body", "") or "")
+        if src.startswith("<") and src.endswith(">"):
+            placeholder = extracted_text or "svg"
+            _render_text_box(
+                slide=slide,
+                region=(left, top, width, height),
+                node=source_node,
+                style=style,
+                theme=theme,
+                text=placeholder,
+            )
+            return True
+        return False
+
+    if src and src != "missing.png" and Path(src).is_file():
+        path = Path(src)
+        try:
+            slide.shapes.add_picture(
+                str(path),
+                Inches(left),
+                Inches(top),
+                Inches(width),
+                Inches(height),
+            )
+            return True
+        except Exception:
+            pass
+
+    label = extracted_text or node_type
+    _render_text_box(
+        slide=slide,
+        region=(left, top, width, height),
+        node=source_node,
+        style=style,
+        theme=theme,
+        text=label,
+    )
+    return True
+
+
 def _render_text_box(
     *,
     slide,
@@ -270,7 +590,12 @@ def _render_text_box(
     text: str,
 ) -> None:
     left, top, width, height = region
-    tb = slide.shapes.add_textbox(left, top, width, height)
+    tb = slide.shapes.add_textbox(
+        Inches(left),
+        Inches(top),
+        Inches(width),
+        Inches(height),
+    )
     tf = tb.text_frame
     _apply_text_frame_style(tf, style, theme=theme)
     paragraph = tf.paragraphs[0]

--- a/src/paperops/slides/codegen/pptx_backend.py
+++ b/src/paperops/slides/codegen/pptx_backend.py
@@ -26,6 +26,7 @@ from paperops.slides.layout.containers import (
     Padding,
 )
 from paperops.slides.components.shapes import Box as ShapeBox
+from paperops.slides.components.table import Table as LayoutTable
 from paperops.slides.components.text import TextBlock
 
 
@@ -237,6 +238,17 @@ def _render_leaf(
     if node_type in {"image", "svg", "icon"}:
         if _render_image_like(slide, node_type, source_node, style, theme, (left, top, width, height), text):
             return
+
+    if node_type == "table":
+        if isinstance(layout_node, LayoutTable):
+            _render_table(
+                slide=slide,
+                region=(left, top, width, height),
+                style=style,
+                layout_node=layout_node,
+                theme=theme,
+            )
+        return
 
     if _is_textual_node(node_type) or text:
         _render_text_box(
@@ -578,6 +590,85 @@ def _render_image_like(
         text=label,
     )
     return True
+
+
+def _render_table(
+    slide,
+    region: tuple[float, float, float, float],
+    style: dict[str, Any],
+    layout_node: LayoutTable,
+    theme: Theme,
+) -> None:
+    left, top, width, height = region
+
+    rows = list(getattr(layout_node, "rows", []))
+    headers = list(getattr(layout_node, "headers", []))
+
+    if not rows and not headers:
+        rows = [[""]]
+
+    row_count = len(rows) + (1 if headers else 0)
+    row_count = max(row_count, 1)
+
+    column_count = max(len(headers), 1)
+    for row in rows:
+        column_count = max(column_count, len(row))
+
+    table_shape = slide.shapes.add_table(
+        row_count,
+        column_count,
+        Inches(left),
+        Inches(top),
+        Inches(max(width, 0.1)),
+        Inches(max(height, 0.1)),
+    )
+    table = table_shape.table
+
+    if headers:
+        header_row = table.rows[0]
+        for column_index, value in enumerate(headers):
+            if column_index >= len(header_row.cells):
+                break
+            header_cell = header_row.cells[column_index]
+            header_cell.text = _as_text_safe(value)
+            paragraph = header_cell.text_frame.paragraphs[0]
+            paragraph.font.bold = True
+            paragraph.font.name = theme.font_family
+            paragraph.font.color.rgb = _text_color(style, theme)
+            paragraph.alignment = PP_ALIGN.CENTER
+        start_row = 1
+        if len(table.rows) > 0:
+            table.rows[0].height = Pt(_resolve_font_size(theme, "body", "body"))
+    else:
+        start_row = 0
+
+    for row_offset, row_data in enumerate(rows):
+        if start_row + row_offset >= len(table.rows):
+            break
+        target_row = table.rows[start_row + row_offset]
+        for column_index, value in enumerate(row_data):
+            if column_index >= len(target_row.cells):
+                break
+            target_cell = target_row.cells[column_index]
+            target_cell.text = _as_text_safe(value)
+
+    cell_bg = _style_value(style, "cell-bg")
+    if cell_bg is not None:
+        try:
+            bg = _resolve_color(theme, cell_bg)
+        except Exception:
+            bg = _resolve_color(theme, "bg")
+        for row in table.rows:
+            for cell in row.cells:
+                if getattr(cell, "fill", None) is not None:
+                    cell.fill.solid()
+                    cell.fill.fore_color.rgb = bg
+
+
+def _as_text_safe(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value)
 
 
 def _render_text_box(

--- a/src/paperops/slides/codegen/pptx_backend.py
+++ b/src/paperops/slides/codegen/pptx_backend.py
@@ -56,11 +56,41 @@ def render_styled_layout(
     for source_slide, layout_root in slide_layout_roots:
         pptx_slide = prs.slides.add_slide(prs.slide_layouts[6])
         _render_slide_background(pptx_slide, source_slide, theme)
+        _render_slide_notes(pptx_slide, source_slide)
         _render_layout_node(pptx_slide, layout_root, theme)
 
     out.parent.mkdir(parents=True, exist_ok=True)
     prs.save(str(out))
     return out
+
+
+def _render_slide_notes(slide, source_node: Node | None) -> None:
+    """Render semantic `<note>` nodes into speaker notes."""
+    notes = _collect_note_texts(source_node)
+    if not notes:
+        return
+
+    notes_slide = slide.notes_slide
+    if notes_slide is None:
+        return
+    notes_slide.notes_text_frame.text = "\n\n".join(notes)
+
+
+def _collect_note_texts(node: Node | None) -> list[str]:
+    if node is None:
+        return []
+    notes: list[str] = []
+
+    if node.type == "note":
+        text = _extract_text(node, None).strip()
+        if text:
+            notes.append(text)
+
+    for child in node.children or []:
+        if isinstance(child, Node):
+            notes.extend(_collect_note_texts(child))
+
+    return notes
 
 
 def _render_slide_background(slide, source_node: Node | None, theme: Theme) -> None:
@@ -221,7 +251,9 @@ def _render_box(
         _apply_text_frame_style(tf, style, theme=theme)
         paragraph = tf.paragraphs[0]
         paragraph.text = text
-    paragraph.alignment = _ALIGN_MAP.get(_style_value(style, "text-align", "center"), PP_ALIGN.LEFT)
+        paragraph.alignment = _ALIGN_MAP.get(
+            _style_value(style, "text-align", "center"), PP_ALIGN.LEFT
+        )
 
 
 def _theme_default_color(theme: Theme, key: str) -> str:

--- a/src/paperops/slides/codegen/pptx_backend.py
+++ b/src/paperops/slides/codegen/pptx_backend.py
@@ -8,7 +8,9 @@ from typing import Any
 from pptx import Presentation
 from pptx.dml.color import RGBColor
 from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.chart import XL_CHART_TYPE
 from pptx.enum.text import PP_ALIGN
+from pptx.chart.data import ChartData
 from pptx.util import Inches, Pt
 
 from paperops.slides.core.constants import SLIDE_HEIGHT, SLIDE_WIDTH
@@ -172,7 +174,7 @@ def _render_leaf(
     width = float(region.width)
     height = float(region.height)
 
-    if node_type in {"box", "kpi"} or isinstance(layout_node, ShapeBox):
+    if node_type in {"box", "kpi"}:
         _render_box(
             slide=slide,
             region=(left, top, width, height),
@@ -181,7 +183,7 @@ def _render_leaf(
             text=text,
         )
         return
-    if node_type == "roundedbox" and not isinstance(layout_node, ShapeBox):
+    if node_type == "roundedbox":
         _render_rounded_box(
             slide=slide,
             region=(left, top, width, height),
@@ -238,6 +240,15 @@ def _render_leaf(
     if node_type in {"image", "svg", "icon"}:
         if _render_image_like(slide, node_type, source_node, style, theme, (left, top, width, height), text):
             return
+    if node_type == "chart":
+        _render_chart(
+            slide=slide,
+            region=(left, top, width, height),
+            style=style,
+            theme=theme,
+            source_node=source_node,
+        )
+        return
 
     if node_type == "table":
         if isinstance(layout_node, LayoutTable):
@@ -248,6 +259,9 @@ def _render_leaf(
                 layout_node=layout_node,
                 theme=theme,
             )
+        return
+
+    if node_type == "note":
         return
 
     if _is_textual_node(node_type) or text:
@@ -705,6 +719,211 @@ def _render_text_box(
         numeric = _to_float(line_height)
         if numeric is not None:
             paragraph.line_spacing = numeric
+
+
+def _chart_type_to_xl(chart_type: str) -> XL_CHART_TYPE:
+    normalized = str(chart_type or "").strip().lower()
+    mapping = {
+        "line": XL_CHART_TYPE.LINE,
+        "line_markers": XL_CHART_TYPE.LINE_MARKERS,
+        "bar": XL_CHART_TYPE.BAR_CLUSTERED,
+        "bar_clustered": XL_CHART_TYPE.BAR_CLUSTERED,
+        "bar_stacked": XL_CHART_TYPE.BAR_STACKED,
+        "column": XL_CHART_TYPE.COLUMN_CLUSTERED,
+        "column_clustered": XL_CHART_TYPE.COLUMN_CLUSTERED,
+        "column_stacked": XL_CHART_TYPE.COLUMN_STACKED,
+        "pie": XL_CHART_TYPE.PIE,
+        "area": XL_CHART_TYPE.AREA,
+        "stacked_area": XL_CHART_TYPE.AREA_STACKED,
+    }
+    return mapping.get(normalized, XL_CHART_TYPE.LINE)
+
+
+def _coerce_chart_values(raw_values: object) -> list[float]:
+    if isinstance(raw_values, (int, float, str)):
+        return [_safe_float(raw_values)]
+    if not isinstance(raw_values, (list, tuple)):
+        return []
+    values: list[float] = []
+    for raw_value in raw_values:
+        value = _safe_float(raw_value)
+        if value is not None:
+            values.append(value)
+    return values
+
+
+def _safe_float(value: object) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        numeric = float(str(value))
+        return numeric
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_chart_series(payload: object) -> list[tuple[str, list[float]]]:
+    if payload is None:
+        return []
+
+    if isinstance(payload, dict):
+        series: list[tuple[str, list[float]]] = []
+        for name, values in payload.items():
+            values_list = _coerce_chart_values(values)
+            if values_list:
+                series.append((str(name), values_list))
+        return series
+
+    if not isinstance(payload, (list, tuple)):
+        return []
+
+    series: list[tuple[str, list[float]]] = []
+    for item in payload:
+        if isinstance(item, dict):
+            name = item.get("name") or item.get("label") or item.get("title")
+            if "data" in item and name is None:
+                name = "Series"
+            values = item.get("values") if isinstance(item, dict) else None
+            if name is None:
+                name = f"Series {len(series) + 1}"
+            values_list = _coerce_chart_values(values if values is not None else item.get("data", []))
+            if values_list:
+                series.append((str(name), values_list))
+            continue
+        if isinstance(item, (list, tuple)):
+            values = [value for value in item if _safe_float(value) is not None]
+            if values:
+                series.append((f"Series {len(series) + 1}", _coerce_chart_values(values)))
+    return series
+
+
+def _resolve_chart_payload(
+    source_node: Node | None,
+    props: dict[str, object],
+) -> tuple[str, list[str], list[tuple[str, list[float]]]]:
+    chart_type = ""
+    if isinstance(props.get("chart_type"), str):
+        chart_type = str(props["chart_type"])
+
+    labels: list[str] | None = None
+    raw_labels = props.get("labels")
+    if isinstance(raw_labels, (list, tuple)):
+        labels = [str(label) for label in raw_labels]
+
+    series: list[tuple[str, list[float]]] = []
+    if isinstance(props.get("series"), (list, tuple, dict)):
+        series = _coerce_chart_series(props["series"])
+
+    data = props.get("data")
+    if isinstance(data, dict):
+        if not series and isinstance(data.get("series"), (list, tuple, dict)):
+            series = _coerce_chart_series(data.get("series"))
+
+        if not labels and "labels" in data and isinstance(data["labels"], (list, tuple)):
+            labels = [str(label) for label in data["labels"]]
+
+        if isinstance(data.get("values"), (list, tuple)):
+            values = _coerce_chart_values(data["values"])
+            if values and not series:
+                series = [("Series", values)]
+
+        if not series:
+            flat_data: list[float] = []
+            flat_labels: list[str] = []
+            for key, value in data.items():
+                maybe_value = _safe_float(value)
+                if maybe_value is not None:
+                    flat_labels.append(str(key))
+                    flat_data.append(maybe_value)
+            if flat_data:
+                if labels is None:
+                    labels = flat_labels
+                series = [("Series", flat_data)]
+
+    if not labels and source_node is not None and source_node.text:
+        labels = [str(source_node.text)]
+
+    if not series:
+        series = [("Series", [0.0])]
+        if labels is None:
+            labels = ["Point 1"]
+    elif labels is None and series:
+        labels = [f"Point {idx + 1}" for idx in range(max(len(values) for _, values in series))]
+
+    normalized_labels: list[str] = []
+    if labels:
+        normalized_labels = [str(item) for item in labels]
+
+    max_len = max(len(values) for _, values in series) if series else 0
+    if normalized_labels and len(normalized_labels) < max_len:
+        normalized_labels.extend(f"Point {idx + 1}" for idx in range(len(normalized_labels) + 1, max_len + 1))
+    elif not normalized_labels and max_len:
+        normalized_labels = [f"Point {idx + 1}" for idx in range(1, max_len + 1)]
+
+    return chart_type, normalized_labels, series
+
+
+def _render_chart(
+    *,
+    slide,
+    region: tuple[float, float, float, float],
+    style: dict[str, Any],
+    theme: Theme,
+    source_node: Node | None,
+) -> None:
+    left, top, width, height = region
+    props = source_node.props if source_node is not None and source_node.props is not None else {}
+    if not isinstance(props, dict):
+        props = {}
+
+    chart_type, labels, series = _resolve_chart_payload(source_node, props)
+    title = _style_value(style, "title", None)
+    if title is None and source_node is not None and source_node.text:
+        title = source_node.text
+    if not props.get("title"):
+        props["title"] = title
+
+    chart_data = ChartData()
+    chart_data.categories = list(labels)
+    for name, values in series:
+        chart_data.add_series(str(name), values)
+
+    try:
+        chart_shape = slide.shapes.add_chart(
+            _chart_type_to_xl(chart_type),
+            Inches(left),
+            Inches(top),
+            Inches(width),
+            Inches(height),
+            chart_data,
+        )
+    except TypeError:
+        chart_shape = slide.shapes.add_chart(
+            XL_CHART_TYPE.LINE,
+            Inches(left),
+            Inches(top),
+            Inches(width),
+            Inches(height),
+            chart_data,
+        )
+
+    chart = chart_shape.chart
+    if props.get("title") or props.get("caption"):
+        chart.has_title = True
+        caption = props.get("title") or props.get("caption")
+        chart.chart_title.text_frame.text = str(caption)
+
+    if len(series) <= 1:
+        chart.has_legend = False
+
+    if not chart_data.categories:
+        return
+
+    for plot in chart.plots:
+        for series_idx in range(len(plot.series)):
+            plot.series[series_idx].has_data_labels = False
 
 
 def _apply_text_frame_style(text_frame, style: dict[str, Any], *, theme: Theme) -> None:

--- a/src/paperops/slides/components/__init__.py
+++ b/src/paperops/slides/components/__init__.py
@@ -1,6 +1,24 @@
 """Core slide nodes: shapes, text, images, tables, and SVG."""
 
+from paperops.slides.components import charts  # noqa: F401
+from paperops.slides.components import semantic  # noqa: F401
 from paperops.slides.components.shapes import Box, RoundedBox, Circle, Badge, Arrow, Line
 from paperops.slides.components.text import TextBlock, BulletList
 from paperops.slides.components.table import Table
 from paperops.slides.components.image import Image, SvgImage
+from paperops.slides.components.charts.chart import Chart
+
+__all__ = [
+    "Arrow",
+    "Badge",
+    "Box",
+    "BulletList",
+    "Chart",
+    "Circle",
+    "Image",
+    "Line",
+    "RoundedBox",
+    "SvgImage",
+    "Table",
+    "TextBlock",
+]

--- a/src/paperops/slides/components/charts/__init__.py
+++ b/src/paperops/slides/components/charts/__init__.py
@@ -1,0 +1,6 @@
+"""Chart components."""
+
+from paperops.slides.components.charts.chart import Chart
+
+__all__ = ["Chart"]
+

--- a/src/paperops/slides/components/charts/chart.py
+++ b/src/paperops/slides/components/charts/chart.py
@@ -1,0 +1,51 @@
+"""Chart component declarations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from paperops.slides.components.registry import register_component
+from paperops.slides.layout.containers import LayoutNode
+from paperops.slides.layout.types import Constraints, IntrinsicSize
+
+
+@register_component(
+    "chart",
+    props_schema={
+        "properties": {
+            "chart_type": {"type": "string", "enum": ["line", "bar", "pie", "area"], "required": True},
+            "data": {"type": "object"},
+            "title": {"type": "string"},
+            "labels": {"type": "array"},
+            "series": {"type": "array"},
+            "height": {"type": ["number", "string"]},
+            "width": {"type": ["number", "string"]},
+        },
+        "required": ["chart_type"],
+    },
+    default_classes=["chart"],
+)
+class _ChartDefinition:
+    pass
+
+
+@dataclass
+class Chart(LayoutNode):
+    """Minimal chart layout placeholder."""
+
+    chart_type: str = "line"
+    data: dict[str, object] = field(default_factory=dict)
+
+    def measure(self, constraints: Constraints, theme) -> IntrinsicSize:
+        width = self.width if self.width is not None else (constraints.max_width or 4.0)
+        height = self.height if self.height is not None else (width * 0.62)
+        return IntrinsicSize(
+            min_width=self.min_width or min(width, 1.0),
+            preferred_width=width,
+            min_height=self.min_height or min(height, 0.5),
+            preferred_height=height,
+        ).clamp(constraints)
+
+    def preferred_size(self, theme, available_width: float) -> tuple[float, float]:
+        intrinsic = self.measure(Constraints(max_width=max(available_width, 0.0)), theme)
+        return intrinsic.preferred_width, intrinsic.preferred_height

--- a/src/paperops/slides/components/image.py
+++ b/src/paperops/slides/components/image.py
@@ -4,8 +4,50 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from paperops.slides.components.registry import register_component
 from paperops.slides.layout.containers import LayoutNode
 from paperops.slides.layout.types import Constraints, IntrinsicSize
+
+
+@register_component(
+    "image",
+    props_schema={
+        "properties": {
+            "src": {"type": "string"},
+            "fit": {"type": "boolean"},
+            "width": {"type": ["number", "string"]},
+            "height": {"type": ["number", "string"]},
+            "alt": {"type": "string"},
+        }
+    },
+    default_classes=["image"],
+)
+@register_component(
+    "svg",
+    props_schema={
+        "properties": {
+            "src": {"type": "string"},
+            "body": {"type": "string"},
+            "fit": {"type": "boolean"},
+            "width": {"type": ["number", "string"]},
+            "height": {"type": ["number", "string"]},
+        }
+    },
+    default_classes=["svg"],
+)
+@register_component(
+    "icon",
+    props_schema={
+        "properties": {
+            "name": {"type": "string"},
+            "size": {"type": ["number", "string"]},
+            "color": {"type": "string"},
+        }
+    },
+    default_classes=["icon"],
+)
+class _ImageDefinition:
+    pass
 
 
 @dataclass

--- a/src/paperops/slides/components/registry.py
+++ b/src/paperops/slides/components/registry.py
@@ -1,58 +1,376 @@
-"""Component registry and declaration helper decorators."""
+"""Component registry and validation helpers.
+
+The registry is the contract between parsed IR nodes and the semantic expansion
+pipeline.  Every registered component declares:
+
+- ``props_schema``: what props are accepted and which are required
+- ``default_classes``: classes injected ahead of user-specified classes
+- optional ``expand`` callback to expand semantic components into IR subtrees
+"""
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Any, Callable
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping
+
+from paperops.slides.ir.node import Node
 
 
 @dataclass(frozen=True)
 class ComponentDefinition:
-    """Metadata describing one registered component."""
+    """Metadata for one component in the registry."""
 
     type: str
-    props_schema: dict[str, Any] = field(default_factory=dict)
-    default_classes: list[str] = field(default_factory=list)
-    expand: Callable[[dict[str, Any]], Any] | None = None
+    props_schema: dict[str, Any] = None
+    default_classes: list[str] | tuple[str, ...] = None
+    expand: Callable[..., Any] | None = None
 
 
+@dataclass(frozen=True)
+class ComponentError(ValueError):
+    """Structured validation error produced by component checks."""
+
+    code: str
+    path: str
+    message: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "args",
+            (f"[{self.code}] {self.path}: {self.message}",),
+        )
+
+
+@dataclass
 class ComponentRegistry:
-    """Simple, strict component registry."""
+    """Global registry for slide components."""
+
+    _definitions: dict[str, ComponentDefinition]
 
     def __init__(self) -> None:
-        self._definitions: dict[str, ComponentDefinition] = {}
+        self._definitions = {}
 
-    def register(
-        self, component_type: str, definition: ComponentDefinition
-    ) -> ComponentDefinition:
-        if component_type in self._definitions:
-            raise ValueError(f"Component '{component_type}' already registered")
-        self._definitions[component_type] = definition
-        return definition
+    def clear(self) -> None:
+        self._definitions.clear()
 
-    def get(self, component_type: str) -> ComponentDefinition:
-        return self._definitions[component_type]
+    def snapshot(self) -> dict[str, ComponentDefinition]:
+        return dict(self._definitions)
 
-    def has(self, component_type: str) -> bool:
-        return component_type in self._definitions
+    def register(self, name: str, definition: ComponentDefinition) -> None:
+        if not isinstance(name, str) or not name:
+            raise TypeError("component type must be a non-empty string")
+        if not isinstance(definition, ComponentDefinition):
+            raise TypeError("definition must be ComponentDefinition")
+        if definition.type != name:
+            raise ValueError("definition type must match registry key")
+        if name in self._definitions:
+            raise ValueError(f"Component {name!r} already registered")
+        self._definitions[name] = definition
+
+    def get(self, name: str) -> ComponentDefinition:
+        return self._definitions[name]
+
+    def has(self, name: str) -> bool:
+        return name in self._definitions
 
     def as_dict(self) -> dict[str, ComponentDefinition]:
         return dict(self._definitions)
+
+
+def _normalise_schema(raw_schema: dict[str, Any] | None) -> tuple[dict[str, dict[str, Any]], set[str]]:
+    """Return ``(properties, required_keys)`` from either schema format.
+
+    Supported input examples:
+    - ``{"properties": {...}, "required": ["label"]}``
+    - ``{"label": {"type": "string", "required": True}}``
+    """
+
+    if not raw_schema:
+        return {}, set()
+
+    if "properties" in raw_schema and isinstance(raw_schema["properties"], dict):
+        properties = {
+            key: dict(value) if isinstance(value, dict) else {"type": value}
+            for key, value in raw_schema["properties"].items()
+            if isinstance(key, str)
+        }
+        required = set(raw_schema.get("required", []) or [])
+        return properties, set(filter(None, (str(key) for key in required)))
+
+    properties: dict[str, dict[str, Any]] = {}
+    required: set[str] = set()
+    for key, rule in raw_schema.items():
+        if not isinstance(key, str):
+            continue
+        if key in {"properties", "required"}:
+            continue
+        if isinstance(rule, Mapping):
+            properties[key] = dict(rule)
+            if rule.get("required") is True:
+                required.add(key)
+        else:
+            properties[key] = {"type": rule}
+
+    for required_name in raw_schema.get("required", []) if isinstance(raw_schema.get("required"), list) else []:
+        if isinstance(required_name, str):
+            required.add(required_name)
+            properties.setdefault(required_name, {"type": "string"})
+
+    return properties, required
+
+
+def _validate_scalar(value: Any, expected: str, path: str) -> None:
+    if expected in {"str", "string"}:
+        if not isinstance(value, str):
+            raise ComponentError("INVALID_PROP_VALUE", path, f"expected string, got {type(value).__name__}")
+    elif expected == "number":
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ComponentError("INVALID_PROP_VALUE", path, f"expected number, got {type(value).__name__}")
+    elif expected == "integer":
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ComponentError("INVALID_PROP_VALUE", path, f"expected integer, got {type(value).__name__}")
+    elif expected in {"boolean", "bool"}:
+        if not isinstance(value, bool):
+            raise ComponentError("INVALID_PROP_VALUE", path, f"expected boolean, got {type(value).__name__}")
+    elif expected == "array":
+        if not isinstance(value, list):
+            raise ComponentError("INVALID_PROP_VALUE", path, f"expected array, got {type(value).__name__}")
+    elif expected == "object":
+        if not isinstance(value, dict):
+            raise ComponentError("INVALID_PROP_VALUE", path, f"expected object, got {type(value).__name__}")
+
+
+def _validate_one(value: Any, rule: dict[str, Any], path: str) -> Any:
+    expected = rule.get("type")
+    if expected is None:
+        return value
+
+    if isinstance(expected, (list, tuple)):
+        for index, candidate in enumerate(expected):
+            try:
+                _validate_scalar(value, str(candidate), f"{path}[{index}]")
+                break
+            except ComponentError:
+                continue
+        else:
+            allowed = ", ".join(str(item) for item in expected)
+            raise ComponentError("INVALID_PROP_VALUE", path, f"expected one of [{allowed}], got {type(value).__name__}")
+
+    else:
+        if isinstance(expected, list):
+            expected = ",".join(str(item) for item in expected)
+        _validate_scalar(value, str(expected), path)
+
+    if "enum" in rule and value not in rule.get("enum"):
+        raise ComponentError(
+            "INVALID_PROP_VALUE",
+            path,
+            f"invalid value {value!r}; expected one of {list(rule.get('enum'))}",
+        )
+
+    return value
+
+
+def _validate_node_props(
+    definition: ComponentDefinition,
+    node: Node,
+    *,
+    path: str,
+    strict: bool,
+) -> dict[str, Any]:
+    """Validate ``props`` for a registered component and return merged defaults."""
+    raw_props = dict(node.props or {})
+    schema = dict(definition.props_schema or {})
+    properties, required = _normalise_schema(schema)
+
+    merged = dict(raw_props)
+    for key in required:
+        if key not in merged and "default" not in properties.get(key, {}):
+            raise ComponentError(
+                "MISSING_REQUIRED_PROP",
+                f"{path}.props",
+                f"Missing required prop {key!r}",
+            )
+
+    for key in properties:
+        if "default" in properties[key] and key not in merged:
+            merged[key] = properties[key]["default"]
+
+    for key, value in list(merged.items()):
+        if key not in properties:
+            raise ComponentError(
+                "UNKNOWN_PROP",
+                f"{path}.props",
+                f"Unknown prop {key!r}",
+            )
+            continue
+        rule = properties[key]
+        merged[key] = _validate_one(value, rule, f"{path}.props.{key}")
+
+    return merged
+
+
+def _merge_classes(default_classes: list[str] | tuple[str, ...] | None, user_class: str | None) -> str:
+    defaults = list(default_classes or [])
+    result: list[str] = []
+    for token in [*(defaults), *(user_class.split() if isinstance(user_class, str) else [])]:
+        token = token.strip()
+        if not token or token in result:
+            continue
+        result.append(token)
+    return " ".join(result)
+
+
+def _build_expanded_node(
+    value: Any,
+    path: str,
+) -> Node:
+    if isinstance(value, Node):
+        return value
+    if isinstance(value, dict):
+        return Node.from_dict(value)
+    raise TypeError(f"{path}: expected node mapping, got {type(value).__name__}")
+
+
+def expand_node(
+    node: Node,
+    *,
+    strict: bool = False,
+    path: str = "root",
+) -> Node:
+    """Validate one node, apply defaults, and expand semantic component nodes."""
+
+    if not isinstance(node, Node):
+        return node
+
+    children = node.children or []
+    expanded_children = [
+        expand_node(child, strict=strict, path=f"{path}.children[{index}]")
+        if isinstance(child, Node)
+        else child
+        for index, child in enumerate(children)
+    ]
+
+    if not registry.has(node.type):
+        if not expanded_children:
+            return Node(
+                type=node.type,
+                class_=node.class_,
+                id=node.id,
+                style=node.style,
+                text=node.text,
+                props=node.props,
+                children=None,
+            )
+        return Node(
+            type=node.type,
+            class_=node.class_,
+            id=node.id,
+            style=node.style,
+            text=node.text,
+            props=node.props,
+            children=expanded_children,
+        )
+
+    definition = registry.get(node.type)
+    validated_props = _validate_node_props(
+        definition,
+        Node(
+            type=node.type,
+            class_=node.class_,
+            id=node.id,
+            style=node.style,
+            text=node.text,
+            props=node.props,
+            children=children,
+        ),
+        path=path,
+        strict=strict,
+    )
+    merged_class = _merge_classes(definition.default_classes, node.class_)
+
+    source_node = Node(
+        type=node.type,
+        class_=merged_class,
+        id=node.id,
+        style=node.style,
+        text=node.text,
+        props=validated_props,
+        children=expanded_children,
+    )
+
+    if definition.expand is None:
+        return source_node
+
+    expanded_node = _call_expand(definition, validated_props, source_node)
+    if expanded_node is None:
+        return source_node
+
+    base_node = _build_expanded_node(expanded_node, path=f"{path}.expanded")
+    merged_default_classes = _merge_classes(definition.default_classes, source_node.class_ or "")
+    merged_expanded_classes = _merge_classes(
+        merged_default_classes.split() if merged_default_classes else None,
+        base_node.class_,
+    )
+
+    if base_node.type == source_node.type:
+        return Node(
+            type=base_node.type,
+            class_=merged_expanded_classes,
+            id=base_node.id or node.id,
+            style=base_node.style,
+            text=base_node.text,
+            props=base_node.props,
+            children=base_node.children,
+        )
+
+    merged = Node(
+        type=base_node.type,
+        class_=merged_expanded_classes,
+        id=base_node.id or node.id,
+        style=base_node.style,
+        text=base_node.text,
+        props=base_node.props,
+        children=base_node.children,
+    )
+    return expand_node(
+        Node(
+            type=merged.type,
+            class_=merged.class_,
+            id=merged.id,
+            style=merged.style,
+            text=merged.text,
+            props=merged.props,
+            children=merged.children,
+        ),
+        strict=strict,
+        path=f"{path}.expanded",
+    )
+
+
+def _call_expand(definition: ComponentDefinition, props: dict[str, Any], node: Node) -> Any:
+    if definition.expand is None:
+        return None
+    expand_fn = definition.expand
+    try:
+        return expand_fn(props, children=node.children, style=node.style)
+    except TypeError:
+        return expand_fn(props)
+
+
+def expand_nodes(nodes: list[Node], *, strict: bool = False) -> list[Node]:
+    return [expand_node(node, strict=strict, path=f"slides[{index}]") for index, node in enumerate(nodes)]
 
 
 def register_component(
     type_name: str,
     *,
     props_schema: dict[str, Any] | None = None,
-    default_classes: list[str] | None = None,
-    expand: Callable[[dict[str, Any]], Any] | None = None,
+    default_classes: list[str] | tuple[str, ...] | None = None,
+    expand: Callable[..., Any] | None = None,
 ):
-    """Decorator to register components.
-
-    Usage:
-        @register_component("kpi", props_schema={"value": {"type": "number"}})
-        class Kpi: ...
-    """
+    """Decorator to register one component type."""
 
     if not type_name or not isinstance(type_name, str):
         raise TypeError("type_name must be a non-empty string")
@@ -60,23 +378,21 @@ def register_component(
     def decorator(target: Any):
         target_schema = props_schema
         if target_schema is None:
-            target_schema = getattr(target, "props_schema", {})
-        target_classes = (
-            default_classes
-            if default_classes is not None
-            else list(getattr(target, "default_classes", []))
-        )
-        target_expand = (
-            expand if expand is not None else getattr(target, "expand", None)
-        )
+            target_schema = getattr(target, "props_schema", None)
+        target_classes = default_classes
+        if target_classes is None:
+            target_classes = getattr(target, "default_classes", None)
+        target_expand = expand if expand is not None else getattr(target, "expand", None)
 
-        definition = ComponentDefinition(
-            type=type_name,
-            props_schema=target_schema or {},
-            default_classes=target_classes or [],
-            expand=target_expand,
+        registry.register(
+            type_name,
+            ComponentDefinition(
+                type=type_name,
+                props_schema=target_schema or {},
+                default_classes=list(target_classes) if target_classes is not None else [],
+                expand=target_expand,
+            ),
         )
-        registry.register(type_name, definition)
         return target
 
     return decorator
@@ -84,4 +400,13 @@ def register_component(
 
 registry = ComponentRegistry()
 
-__all__ = ["ComponentDefinition", "ComponentRegistry", "register_component", "registry"]
+__all__ = [
+    "ComponentDefinition",
+    "ComponentError",
+    "ComponentRegistry",
+    "expand_node",
+    "expand_nodes",
+    "register_component",
+    "registry",
+    "_merge_classes",
+]

--- a/src/paperops/slides/components/semantic/__init__.py
+++ b/src/paperops/slides/components/semantic/__init__.py
@@ -436,7 +436,8 @@ class Spacer:
                 style_payload["width"] = size
 
         return {
-            "type": "_spacer",
+            "type": "spacer",
+            "class": "spacer",
             "style": style_payload,
             "children": [],
         }

--- a/src/paperops/slides/components/semantic/__init__.py
+++ b/src/paperops/slides/components/semantic/__init__.py
@@ -1,0 +1,472 @@
+"""Semantic components for SlideCraft.
+
+Each component declares its prop schema and expands into one or more atomic IR
+nodes before style resolution.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from paperops.slides.components.registry import register_component
+from paperops.slides.ir.node import Node
+
+
+def _coerce_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def _as_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+def _flatten_node_text(children: list[Any]) -> str:
+    texts: list[str] = []
+    for child in children:
+        if isinstance(child, str):
+            texts.append(child)
+        elif isinstance(child, Node):
+            if child.text is not None:
+                texts.append(_as_text(child.text))
+            if child.children:
+                texts.append(_flatten_node_text(list(child.children)))
+        elif isinstance(child, dict) and "text" in child:
+            text = child.get("text")
+            if text is not None:
+                texts.append(_as_text(text))
+    return "".join(texts).strip()
+
+
+def _normalize_children(children: list[Any] | None) -> list[Any]:
+    normalized: list[Any] = []
+    for item in _coerce_list(children):
+        if isinstance(item, Node):
+            normalized.append(item.to_dict())
+        elif isinstance(item, (dict, str)):
+            normalized.append(item)
+    return normalized
+
+
+def _text_node(content: Any, *, classes: str = "text") -> dict[str, Any]:
+    return {"type": "text", "class": classes, "text": _as_text(content)}
+
+
+@register_component(
+    "card",
+    props_schema={},
+    default_classes=["card"],
+)
+class Card:
+    @staticmethod
+    def expand(props, children=None, style=None):
+        body = _normalize_children(children)
+        if not body:
+            body = [{"type": "text", "class": "prose", "text": ""}]
+        return {
+            "type": "padding",
+            "class": "card",
+            "children": [
+                {
+                    "type": "box",
+                    "class": "card-body",
+                    "children": body,
+                }
+            ],
+        }
+
+
+@register_component(
+    "kpi",
+    props_schema={
+        "properties": {
+            "label": {"type": "string", "required": True},
+            "value": {"type": "string", "required": True},
+            "delta": {"type": "string"},
+            "trend": {
+                "type": "string",
+                "enum": ["positive", "negative", "neutral"],
+                "default": "neutral",
+            },
+        },
+        "required": ["label", "value"],
+    },
+    default_classes=["kpi"],
+)
+class KPI:
+    @staticmethod
+    def expand(props, children=None, style=None):
+        label = props["label"]
+        value = props["value"]
+        delta = props.get("delta")
+        trend = props.get("trend", "neutral")
+        payload = [
+            _text_node(label, classes="label"),
+            _text_node(value, classes="value"),
+        ]
+        if delta is not None:
+            payload.append(
+                _text_node(delta, classes=f"delta {trend}")
+            )
+        payload.extend(_normalize_children(children))
+
+        return {
+            "type": "card",
+            "children": payload,
+        }
+
+
+@register_component(
+    "callout",
+    props_schema={
+        "properties": {
+            "kind": {"type": "string"},
+            "text": {"type": "string"},
+        }
+    },
+    default_classes=["callout"],
+)
+class Callout:
+    @staticmethod
+    def expand(props, children=None, style=None):
+        kind = _as_text(props.get("kind", "note"))
+        text = props.get("text")
+        if text is None and children:
+            text = _flatten_node_text(_normalize_children(children))
+            children = []
+        if text is None:
+            text = ""
+        payload = [
+            _text_node(kind, classes="badge"),
+            _text_node(text, classes="prose"),
+        ]
+        payload.extend(_normalize_children(children))
+        return {"type": "card", "children": payload}
+
+
+@register_component(
+    "quote",
+    props_schema={
+        "properties": {
+            "text": {"type": "string", "required": True},
+            "author": {"type": "string"},
+        },
+        "required": ["text"],
+    },
+    default_classes=["quote"],
+)
+class Quote:
+    @staticmethod
+    def expand(props, children=None, style=None):
+        body = props["text"]
+        return {
+            "type": "card",
+            "children": [
+                _text_node("“", classes="quote-mark"),
+                _text_node(body, classes="body"),
+                *(
+                    [_text_node(props.get("author"), classes="author")]
+                    if props.get("author")
+                    else []
+                ),
+            ],
+        }
+
+
+@register_component(
+    "pullquote",
+    props_schema={
+        "properties": {
+            "text": {"type": "string", "required": True},
+            "author": {"type": "string"},
+        },
+        "required": ["text"],
+    },
+    default_classes=["pullquote"],
+)
+class PullQuote:
+    @staticmethod
+    def expand(props, children=None, style=None):
+        body = props["text"]
+        payload = [
+            _text_node(body, classes="body"),
+        ]
+        if props.get("author"):
+            payload.append(_text_node(props.get("author"), classes="author"))
+        payload.extend(_normalize_children(children))
+        return {"type": "card", "children": payload}
+
+
+@register_component(
+    "keypoint",
+    props_schema={
+        "properties": {
+            "number": {"type": "string"},
+            "title": {"type": "string"},
+            "body": {"type": "string"},
+        }
+    },
+    default_classes=["keypoint"],
+)
+class KeyPoint:
+    @staticmethod
+    def expand(props, children=None, style=None):
+        payload = []
+        if props.get("number"):
+            payload.append(_text_node(props["number"], classes="number"))
+        if props.get("title"):
+            payload.append(_text_node(props["title"], classes="title"))
+        if props.get("body"):
+            payload.append(_text_node(props["body"], classes="body"))
+        extra = _normalize_children(children)
+        if extra:
+            payload.extend(extra)
+        return {"type": "card", "children": payload}
+
+
+@register_component(
+    "stepper",
+    props_schema={
+        "properties": {
+            "steps": {"type": "array"},
+            "start": {"type": ["number", "string"], "default": 1},
+        }
+    },
+    default_classes=["stepper"],
+)
+class Stepper:
+    @staticmethod
+    def expand(props, children=None, style=None):
+        raw_steps = props.get("steps") or []
+        start = int(props.get("start", 1))
+        steps = _coerce_list(raw_steps)
+        payload: list[Any] = []
+
+        for index, step in enumerate(steps):
+            if isinstance(step, dict):
+                label = _as_text(step.get("label", step.get("title", "")))
+                desc = _as_text(step.get("desc", step.get("description", "")))
+            elif isinstance(step, str):
+                label = step
+                desc = ""
+            else:
+                label = str(step)
+                desc = ""
+
+            step_no = start + index
+            step_nodes = [
+                _text_node(step_no, classes="number"),
+                _text_node(label, classes="label"),
+            ]
+            if desc:
+                step_nodes.append(_text_node(desc, classes="desc"))
+            payload.append({"type": "stack", "class": "step", "children": step_nodes})
+
+        payload.extend(_normalize_children(children))
+        return {"type": "stack", "class": "stepper", "children": payload}
+
+
+@register_component(
+    "timeline",
+    props_schema={
+        "properties": {
+            "items": {"type": "array"},
+        }
+    },
+    default_classes=["timeline"],
+)
+class Timeline:
+    @staticmethod
+    def expand(props, children=None, style=None):
+        payload: list[Any] = []
+        for item in _coerce_list(props.get("items")):
+            date = ""
+            title = ""
+            desc = ""
+            if isinstance(item, dict):
+                date = _as_text(item.get("date", ""))
+                title = _as_text(item.get("title", ""))
+                desc = _as_text(item.get("desc", item.get("description", "")))
+            elif isinstance(item, str):
+                title = item
+            else:
+                title = str(item)
+
+            node_children = []
+            if date:
+                node_children.append(_text_node(date, classes="date"))
+            if title:
+                node_children.append(_text_node(title, classes="title"))
+            if desc:
+                node_children.append(_text_node(desc, classes="desc"))
+            if not node_children:
+                node_children = [_text_node("", classes="empty")]
+            payload.append({"type": "stack", "class": "timeline-item", "children": node_children})
+
+        if not payload:
+            payload = [{"type": "text", "class": "timeline-empty", "text": ""}]
+        extra = _normalize_children(children)
+        if extra:
+            payload.extend(extra)
+        return {"type": "stack", "class": "timeline", "children": payload}
+
+
+@register_component(
+    "figure",
+    props_schema={
+        "properties": {
+            "src": {"type": "string"},
+            "body": {"type": "string"},
+            "chart_type": {"type": "string", "enum": ["line", "bar", "pie", "area"]},
+            "caption": {"type": "string"},
+            "source": {"type": "string"},
+        }
+    },
+    default_classes=["figure"],
+)
+class Figure:
+    @staticmethod
+    def expand(props, children=None, style=None):
+        payload: list[Any] = []
+
+        if props.get("src"):
+            payload.append(
+                {
+                    "type": "image",
+                    "class": "media",
+                    "props": {"src": props.get("src")},
+                }
+            )
+        elif props.get("body"):
+            payload.append(
+                {
+                    "type": "svg",
+                    "class": "media",
+                    "props": {"body": props.get("body")},
+                }
+            )
+        elif props.get("chart_type"):
+            payload.append(
+                {
+                    "type": "chart",
+                    "class": "media",
+                    "props": {
+                        "chart_type": props.get("chart_type"),
+                    },
+                }
+            )
+        elif children:
+            payload.extend(_normalize_children(children))
+
+        if not payload:
+            payload.append({"type": "text", "class": "caption", "text": "figure"})
+
+        caption = props.get("caption")
+        if caption is not None:
+            payload.append(_text_node(caption, classes="caption"))
+        source = props.get("source")
+        if source:
+            payload.append(_text_node(source, classes="source"))
+
+        return {"type": "card", "children": payload}
+
+
+@register_component(
+    "caption",
+    props_schema={
+        "properties": {
+            "text": {"type": "string", "required": True},
+        },
+        "required": ["text"],
+    },
+    default_classes=["caption"],
+)
+class Caption:
+    @staticmethod
+    def expand(props, children=None, style=None):
+        if props.get("text"):
+            return {
+                "type": "text",
+                "class": "caption",
+                "text": props["text"],
+            }
+
+        text = _flatten_node_text(_normalize_children(children))
+        return {
+            "type": "text",
+            "class": "caption",
+            "text": text,
+        }
+
+
+@register_component(
+    "spacer",
+    props_schema={
+        "properties": {
+            "size": {"type": ["number", "string"]},
+            "orientation": {
+                "type": "string",
+                "enum": ["h", "v", "horizontal", "vertical"],
+                "default": "h",
+            },
+            "width": {"type": ["number", "string"]},
+            "height": {"type": ["number", "string"]},
+        }
+    },
+    default_classes=["spacer"],
+)
+class Spacer:
+    @staticmethod
+    def expand(props, children=None, style=None):
+        style_payload = dict(props or {})
+        size = style_payload.pop("size", None)
+        orientation = style_payload.pop("orientation", "h")
+
+        if style_payload.get("width") is None and style_payload.get("height") is None and size is not None:
+            if orientation in {"v", "vertical"}:
+                style_payload["height"] = size
+            else:
+                style_payload["width"] = size
+
+        return {
+            "type": "_spacer",
+            "style": style_payload,
+            "children": [],
+        }
+
+
+@register_component(
+    "note",
+    props_schema={},
+    default_classes=["note"],
+)
+class Note:
+    @staticmethod
+    def expand(props, children=None, style=None):
+        return {
+            "type": "note",
+            "children": _normalize_children(children),
+        }
+
+
+__all__ = [
+    "Callout",
+    "Card",
+    "Caption",
+    "Figure",
+    "KeyPoint",
+    "KPI",
+    "Note",
+    "PullQuote",
+    "Quote",
+    "Spacer",
+    "Stepper",
+    "Timeline",
+]

--- a/src/paperops/slides/components/shapes.py
+++ b/src/paperops/slides/components/shapes.py
@@ -4,10 +4,89 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from paperops.slides.components.registry import register_component
+
 from paperops.slides.core.constants import Align, Direction
 from paperops.slides.layout.autofit import TextStyle, build_intrinsic_size, measure_text_intrinsic
 from paperops.slides.layout.containers import LayoutNode
 from paperops.slides.layout.types import Constraints, IntrinsicSize
+
+
+@register_component(
+    "box",
+    props_schema={
+        "properties": {
+            "text": {"type": "string"},
+            "style": {"type": "object"},
+        }
+    },
+    default_classes=["box"],
+)
+@register_component(
+    "roundedbox",
+    props_schema={
+        "properties": {
+            "text": {"type": "string"},
+        }
+    },
+    default_classes=["rounded-box"],
+)
+class _ShapeBoxDefinition:
+    pass
+
+
+@register_component(
+    "circle",
+    props_schema={
+        "properties": {
+            "text": {"type": "string"},
+            "radius": {"type": "number"},
+        }
+    },
+    default_classes=["circle"],
+)
+@register_component(
+    "badge",
+    props_schema={"text": {"type": "string"}},
+    default_classes=["badge"],
+)
+class _ShapeMarkerDefinition:
+    pass
+
+
+@register_component(
+    "line",
+    props_schema={
+        "from": {"type": "string"},
+        "to": {"type": "string"},
+        "style": {"type": "object"},
+        "color": {"type": "string"},
+        "weight": {"type": ["number", "string"]},
+    },
+    default_classes=["line"],
+)
+@register_component(
+    "arrow",
+    props_schema={
+        "from": {"type": "string"},
+        "to": {"type": "string"},
+        "head": {"type": "string"},
+        "color": {"type": "string"},
+        "weight": {"type": ["number", "string"]},
+    },
+    default_classes=["arrow"],
+)
+@register_component(
+    "divider",
+    props_schema={
+        "orientation": {"type": "string", "enum": ["horizontal", "vertical"]},
+        "thickness": {"type": "number"},
+        "length": {"type": "number"},
+    },
+    default_classes=["divider"],
+)
+class _ShapeLineDefinition:
+    pass
 
 
 def _resolve_font_pt(theme, size: str | float) -> float:

--- a/src/paperops/slides/components/table.py
+++ b/src/paperops/slides/components/table.py
@@ -4,8 +4,27 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from paperops.slides.components.registry import register_component
 from paperops.slides.layout.containers import LayoutNode
 from paperops.slides.layout.types import Constraints, IntrinsicSize
+
+
+@register_component(
+    "table",
+    props_schema={
+        "properties": {
+            "headers": {"type": "array"},
+            "rows": {"type": "array"},
+            "header_color": {"type": "string"},
+            "header_text_color": {"type": "string"},
+            "font_size": {"type": ["number", "string"]},
+            "row_height": {"type": ["number", "string"]},
+        }
+    },
+    default_classes=["table"],
+)
+class _TableDefinition:
+    pass
 
 
 @dataclass

--- a/src/paperops/slides/components/text.py
+++ b/src/paperops/slides/components/text.py
@@ -1,14 +1,67 @@
-"""Text components — TextBlock, BulletList."""
+"""Text components and text-only measurements."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from paperops.slides.components.shapes import _resolve_font_pt
+from paperops.slides.components.registry import register_component
 from paperops.slides.core.constants import Align
 from paperops.slides.layout.autofit import TextStyle, build_intrinsic_size, measure_text_intrinsic
 from paperops.slides.layout.containers import LayoutNode
 from paperops.slides.layout.types import Constraints, IntrinsicSize
+
+
+@register_component(
+    "text",
+    props_schema={
+        "properties": {
+            "text": {"type": "string"},
+        }
+    },
+    default_classes=["text"],
+)
+@register_component(
+    "prose",
+    props_schema={
+        "properties": {
+            "text": {"type": "string"},
+        }
+    },
+    default_classes=["prose"],
+)
+class _TextDefinition:
+    pass
+
+
+@register_component(
+    "title",
+    props_schema={
+        "properties": {
+            "text": {"type": "string"},
+        }
+    },
+    default_classes=["title"],
+)
+@register_component(
+    "subtitle",
+    props_schema={
+        "properties": {
+            "text": {"type": "string"},
+        }
+    },
+    default_classes=["subtitle"],
+)
+@register_component(
+    "heading",
+    props_schema={
+        "properties": {
+            "text": {"type": "string"},
+        }
+    },
+    default_classes=["heading"],
+)
+class _TextStyleDefinition:
+    pass
 
 
 @dataclass
@@ -103,9 +156,9 @@ class BulletList(LayoutNode):
             style = TextStyle(
                 font_family=font_family,
                 font_size_pt=pt,
-                line_spacing=self.line_spacing,
-                margin_x=self.margin_x,
-                margin_y=0.0,
+                bold=False,
+                margin_x=self.margin_x * 2,
+                margin_y=self.margin_y * 2,
             )
             item_intrinsic = measure_text_intrinsic(text, style, max_width_inches=usable_width)
             min_width = max(min_width, item_intrinsic.min_width + indent_width)
@@ -124,3 +177,9 @@ class BulletList(LayoutNode):
     def preferred_size(self, theme, available_width: float) -> tuple[float, float]:
         intrinsic = self.measure(Constraints(max_width=max(available_width, 0.0)), theme)
         return intrinsic.preferred_width, intrinsic.preferred_height
+
+
+def _resolve_font_pt(theme, size: str | float) -> float:
+    if theme is not None:
+        return theme.resolve_font_size(size)
+    return float(size) if isinstance(size, (int, float)) else 18.0

--- a/src/paperops/slides/layout/containers.py
+++ b/src/paperops/slides/layout/containers.py
@@ -79,13 +79,13 @@ class Flex(LayoutNode):
 
     def main_gap(self) -> float:
         if self.direction == "column":
-            return self.row_gap if self.row_gap is not None else self.gap
-        return self.column_gap if self.column_gap is not None else self.gap
+            return float(self.row_gap) if self.row_gap is not None else float(self.gap or 0.0)
+        return float(self.column_gap) if self.column_gap is not None else float(self.gap or 0.0)
 
     def cross_gap(self) -> float:
         if self.direction == "column":
-            return self.column_gap if self.column_gap is not None else self.gap
-        return self.row_gap if self.row_gap is not None else self.gap
+            return float(self.column_gap) if self.column_gap is not None else float(self.gap or 0.0)
+        return float(self.row_gap) if self.row_gap is not None else float(self.gap or 0.0)
 
     def measure(self, constraints: Constraints, theme) -> IntrinsicSize:
         if not self.children:

--- a/src/paperops/slides/layout/engine.py
+++ b/src/paperops/slides/layout/engine.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from paperops.slides.core.constants import CONTENT_REGION, Region, SLIDE_HEIGHT, SLIDE_WIDTH
 from paperops.slides.ir.node import Node
+from paperops.slides.components.table import Table as LayoutTable
 from paperops.slides.components.text import TextBlock
 from paperops.slides.components.shapes import Box as ShapeBox
 from paperops.slides.layout.containers import Absolute, AbsoluteItem, Flex, Grid, GridItem, HStack, Layer, LayoutNode, Padding
@@ -124,6 +125,12 @@ def _as_float(layout_node: LayoutNode, attr: str, value: Any, *, fallback: float
     return number
 
 
+def _as_text(value: Any, fallback: str = "") -> str:
+    if value is None:
+        return fallback
+    return str(value)
+
+
 def _parse_grid_tracks(raw: Any) -> list[TrackSpec] | None:
     if raw is None:
         return None
@@ -200,6 +207,7 @@ def _build_layout_leaf(node: Node, theme) -> LayoutNode:
     style = _resolve_layout_metrics_from_style(node)
     text = _extract_node_text(node)
     node_type = node.type
+    props = dict(node.props or {})
 
     if node_type in {"box", "kpi"}:
         props = dict(node.props or {})
@@ -223,6 +231,88 @@ def _build_layout_leaf(node: Node, theme) -> LayoutNode:
             bold=_is_bold(style.get("font-weight")),
             align=_build_style_text_align(style),
         )
+        _apply_style_to_layout_node(layout, node)
+        _attach_source(layout, node)
+        return layout
+
+    if node_type in {"image", "svg", "icon"}:
+        text = (
+            text
+            or _as_text(props.get("name"), "")
+            or _as_text(props.get("body"), "")
+            or _as_text(props.get("src"), "")
+            or f"{node_type}"
+        )
+        layout = TextBlock(
+            text=_as_text(f"[{node_type}] ") + text,
+            font_size=_build_style_font_size(style, theme),
+            color=str(style.get("color", "text")),
+            align=_build_style_text_align(style),
+            bold=False,
+            italic=False,
+            line_spacing=float(style.get("line-height", 1.25)),
+            margin_x=float(style.get("padding-left", 0.0) or 0.0),
+            margin_y=float(style.get("padding-top", 0.0) or 0.0),
+        )
+        _apply_style_to_layout_node(layout, node)
+        _attach_source(layout, node)
+        return layout
+
+    if node_type == "chart":
+        title = _as_text(props.get("title"), "")
+        chart_type = _as_text(props.get("chart_type"), "chart")
+        text = title or f"{chart_type} chart"
+        layout = TextBlock(
+            text=text,
+            font_size=_build_style_font_size(style, theme),
+            color=str(style.get("color", "text")),
+            align=_build_style_text_align(style),
+            bold=True,
+            italic=False,
+            line_spacing=float(style.get("line-height", 1.25)),
+            margin_x=float(style.get("padding-left", 0.0) or 0.0),
+            margin_y=float(style.get("padding-top", 0.0) or 0.0),
+        )
+        _apply_style_to_layout_node(layout, node)
+        _attach_source(layout, node)
+        return layout
+
+    if node_type == "table":
+        rows = props.get("rows", [])
+        headers = props.get("headers", [])
+        layout = LayoutTable(
+            headers=headers if isinstance(headers, list) else [],
+            rows=rows if isinstance(rows, list) else [],
+        )
+        _apply_style_to_layout_node(layout, node)
+        _attach_source(layout, node)
+        return layout
+
+    if node_type in {"line", "arrow", "divider"}:
+        text = "—" if text == "" else text
+        layout = TextBlock(
+            text=_as_text(text),
+            font_size=_build_style_font_size(style, theme),
+            color=str(style.get("color", "text")),
+            align=_build_style_text_align(style),
+            bold=False,
+            italic=False,
+            line_spacing=float(style.get("line-height", 1.25)),
+            margin_x=float(style.get("padding-left", 0.0) or 0.0),
+            margin_y=float(style.get("padding-top", 0.0) or 0.0),
+        )
+        _apply_style_to_layout_node(layout, node)
+        _attach_source(layout, node)
+        return layout
+
+    if node_type == "spacer":
+        layout = LayoutNode()
+        _apply_style_to_layout_node(layout, node)
+        _attach_source(layout, node)
+        return layout
+
+    if node_type == "note":
+        layout = LayoutNode()
         _apply_style_to_layout_node(layout, node)
         _attach_source(layout, node)
         return layout
@@ -367,10 +457,7 @@ def _ir_node_to_layout(node: Node, theme) -> LayoutNode:
     if node_type == "box" or node_type == "kpi":
         return _build_layout_leaf(node, theme)
 
-    layout = LayoutNode(
-        children=_build_layout_children(node, theme),
-    )
-    _apply_style_to_layout_node(layout, node)
+    layout = _build_layout_leaf(node, theme)
     _attach_source(layout, node)
     return layout
 

--- a/src/paperops/slides/layout/engine.py
+++ b/src/paperops/slides/layout/engine.py
@@ -9,6 +9,7 @@ from paperops.slides.ir.node import Node
 from paperops.slides.components.table import Table as LayoutTable
 from paperops.slides.components.text import TextBlock
 from paperops.slides.components.shapes import Box as ShapeBox
+from paperops.slides.components.shapes import RoundedBox
 from paperops.slides.layout.containers import Absolute, AbsoluteItem, Flex, Grid, GridItem, HStack, Layer, LayoutNode, Padding
 from paperops.slides.layout.types import Constraints, IntrinsicSize, LayoutIssue, TrackSpec
 
@@ -230,6 +231,28 @@ def _build_layout_leaf(node: Node, theme) -> LayoutNode:
             font_size=_build_style_font_size(style, theme),
             bold=_is_bold(style.get("font-weight")),
             align=_build_style_text_align(style),
+        )
+        _apply_style_to_layout_node(layout, node)
+        _attach_source(layout, node)
+        return layout
+
+    if node_type == "roundedbox":
+        text = text or _as_text(props.get("text"), "")
+        raw_radius = style.get("radius")
+        if isinstance(raw_radius, (int, float)):
+            radius = float(raw_radius)
+        else:
+            radius = _safe_float(raw_radius)
+        if radius is None:
+            radius = 0.08
+        layout = RoundedBox(
+            text=text,
+            color=str(style.get("bg", "bg_alt")),
+            text_color=str(style.get("color", "text")),
+            font_size=_build_style_font_size(style, theme),
+            bold=_is_bold(style.get("font-weight")),
+            align=_build_style_text_align(style),
+            radius=radius,
         )
         _apply_style_to_layout_node(layout, node)
         _attach_source(layout, node)
@@ -500,6 +523,17 @@ def _to_float(value: Any, *, fallback: float = 0.0) -> float:
         return float(value)
     except (TypeError, ValueError):
         return fallback
+
+
+def _safe_float(value: Any) -> float | None:
+    if value in {"auto", "inherit", "none", None}:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
 
 
 

--- a/src/paperops/slides/style/__init__.py
+++ b/src/paperops/slides/style/__init__.py
@@ -12,6 +12,8 @@ from paperops.slides.style.cascade import (
 )
 from paperops.slides.style.selector import ParsedSelector, parse_selector, specificity
 from paperops.slides.style.stylesheet import StyleSheet
+from paperops.slides.style.sheet_registry import UnknownSheetError, clear_sheets, get_sheet, list_sheets, register_sheet
+from paperops.slides.style import sheets  # type: ignore  # noqa: F401
 
 __all__ = [
     "CascadeResult",
@@ -22,4 +24,9 @@ __all__ = [
     "parse_selector",
     "resolve_computed_styles",
     "specificity",
+    "UnknownSheetError",
+    "clear_sheets",
+    "get_sheet",
+    "list_sheets",
+    "register_sheet",
 ]

--- a/src/paperops/slides/style/sheet_registry.py
+++ b/src/paperops/slides/style/sheet_registry.py
@@ -1,0 +1,62 @@
+"""Sheet registry for named style presets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from paperops.slides.style.stylesheet import StyleSheet
+
+
+_REGISTRY: dict[str, StyleSheet] = {}
+
+
+@dataclass(frozen=True)
+class UnknownSheetError(ValueError):
+    """Raised when a sheet name is not registered."""
+
+
+def register_sheet(name: str, sheet: StyleSheet | Mapping[str, Mapping[str, Any]]) -> None:
+    """Register a named sheet.
+
+    Parameters:
+        name: public sheet name
+        sheet: stylesheet mapping or StyleSheet instance
+    """
+    if not isinstance(name, str) or not name.strip():
+        raise TypeError("sheet name must be a non-empty string")
+    sheet_name = name.strip()
+
+    compiled = sheet if isinstance(sheet, StyleSheet) else StyleSheet(sheet)
+    if sheet_name in _REGISTRY:
+        raise ValueError(f"Sheet {sheet_name!r} is already registered")
+
+    _REGISTRY[sheet_name] = compiled
+
+
+def get_sheet(name: str) -> StyleSheet:
+    """Resolve registered sheet by name."""
+    if not isinstance(name, str) or not name.strip():
+        raise TypeError("sheet name must be a non-empty string")
+    if name not in _REGISTRY:
+        raise UnknownSheetError(f"Unknown style sheet {name!r}")
+    return _REGISTRY[name]
+
+
+def list_sheets() -> dict[str, StyleSheet]:
+    """Return a snapshot of the sheet registry."""
+    return dict(_REGISTRY)
+
+
+def clear_sheets() -> None:
+    """Clear all registered sheets (test-only helper)."""
+    _REGISTRY.clear()
+
+
+__all__ = [
+    "UnknownSheetError",
+    "clear_sheets",
+    "get_sheet",
+    "list_sheets",
+    "register_sheet",
+]

--- a/src/paperops/slides/style/sheets/__init__.py
+++ b/src/paperops/slides/style/sheets/__init__.py
@@ -1,0 +1,32 @@
+"""Built-in style sheets."""
+
+from __future__ import annotations
+
+from paperops.slides.style.sheet_registry import register_sheet
+from .default import SHEET as default
+from .keynote import SHEET as keynote
+from .minimal import SHEET as minimal
+from .academic import SHEET as academic
+from .seminar import SHEET as seminar
+from .whitepaper import SHEET as whitepaper
+from .pitch import SHEET as pitch
+
+
+# Register all built-ins eagerly so they are available by `sheet` name.
+register_sheet("default", default)
+register_sheet("minimal", minimal)
+register_sheet("academic", academic)
+register_sheet("seminar", seminar)
+register_sheet("keynote", keynote)
+register_sheet("whitepaper", whitepaper)
+register_sheet("pitch", pitch)
+
+__all__ = [
+    "default",
+    "minimal",
+    "academic",
+    "seminar",
+    "keynote",
+    "whitepaper",
+    "pitch",
+]

--- a/src/paperops/slides/style/sheets/academic.py
+++ b/src/paperops/slides/style/sheets/academic.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from paperops.slides.style.stylesheet import StyleSheet
+
+SHEET = StyleSheet(
+    {
+        ".cover": {"padding": "xl", "bg": "bg"},
+        ".title": {"font": "title", "font-weight": "bold", "color": "text"},
+        ".subtitle": {"font": "subtitle", "color": "text_mid"},
+        ".heading": {"font": "heading", "color": "text"},
+        ".text": {"font": "body", "color": "text", "line-height": 1.35},
+        ".prose": {"font": "body", "color": "text", "line-height": 1.4},
+        ".card": {"bg": "bg_alt", "padding": "md", "border": "border", "radius": "md"},
+        ".kpi": {"bg": "bg_accent", "padding": "sm", "gap": "xs", "border": "border"},
+        ".label": {"font": "caption", "color": "text_mid", "font-weight": "bold"},
+        ".value": {"font": "heading", "color": "primary"},
+        ".delta": {"font": "caption"},
+        ".positive": {"color": "positive"},
+        ".negative": {"color": "negative"},
+        ".neutral": {"color": "text_mid"},
+        ".callout": {"bg": "bg", "border": "accent", "padding": "md"},
+        ".quote": {"bg": "bg_alt", "padding": "md", "border-left": ["accent", "md"], "gap": "sm"},
+        ".pullquote": {"bg": "bg", "padding": "xl", "gap": "xs", "border-left": ["primary", "lg"]},
+        ".timeline": {"gap": "md"},
+        ".timeline-item": {"padding": "sm", "bg": "bg_alt"},
+        ".table": {"border": "border", "padding": "xs", "bg": "bg"},
+        ".chart": {"bg": "bg_alt", "padding": "md"},
+        ".image": {"border": "border", "padding": "xs"},
+        ".figure": {"gap": "xs", "padding": "md"},
+        ".caption": {"font": "caption", "color": "text_mid"},
+        ".source": {"font": "caption", "color": "text_light"},
+        ".note": {"font": "small", "color": "text_light", "margin-top": "xs"},
+    }
+)

--- a/src/paperops/slides/style/sheets/default.py
+++ b/src/paperops/slides/style/sheets/default.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from paperops.slides.style.stylesheet import StyleSheet
+
+SHEET = StyleSheet(
+    {
+        "slide": {"padding": "md", "bg": "bg"},
+        ".title": {"font": "title", "color": "text", "margin-bottom": 0.0},
+        ".subtitle": {"font": "subtitle", "color": "text_mid", "margin-bottom": 0.0},
+        ".heading": {"font": "heading", "color": "text"},
+        ".text": {"font": "body", "color": "text"},
+        ".prose": {"font": "body", "color": "text"},
+        ".card": {"bg": "bg_alt", "padding": "md", "radius": "md", "gap": "sm"},
+        ".kpi": {"bg": "bg_accent", "padding": "md", "gap": "xs"},
+        ".callout": {"bg": "bg_alt", "padding": "md"},
+        ".quote": {"bg": "bg_alt", "padding": "md"},
+        ".pullquote": {"bg": "bg_accent", "padding": "lg"},
+        ".keypoint": {"bg": "bg_alt", "padding": "sm"},
+        ".stepper": {"gap": "sm"},
+        ".timeline": {"gap": "sm"},
+        ".timeline-item": {"padding": "sm", "border": "border"},
+        ".figure": {"bg": "bg_alt", "padding": "sm", "gap": "sm"},
+        ".caption": {"font": "caption", "color": "text_mid"},
+        ".spacer": {"bg": "none"},
+        ".note": {"font": "caption", "color": "text_light"},
+    }
+)

--- a/src/paperops/slides/style/sheets/keynote.py
+++ b/src/paperops/slides/style/sheets/keynote.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from paperops.slides.style.stylesheet import StyleSheet
+
+SHEET = StyleSheet(
+    {
+        ".cover": {"padding": "xl", "bg": "bg", "align": "center", "gap": "lg"},
+        ".title": {"font": "title", "font-weight": "bold", "color": "text"},
+        ".subtitle": {"font": "subtitle", "color": "accent"},
+        ".heading": {"font": "heading", "color": "primary"},
+        ".text": {"font": "body", "color": "text", "line-height": 1.1},
+        ".prose": {"font": "body", "color": "text", "line-height": 1.15},
+        ".card": {"bg": "bg_accent", "padding": "lg", "radius": "sm", "gap": "sm"},
+        ".kpi": {"bg": "accent", "color": "bg", "padding": "md", "gap": "xs"},
+        ".kpi .label": {"color": "bg"},
+        ".kpi .value": {"font": "title", "font-weight": "bold"},
+        ".delta": {"font": "caption", "color": "bg"},
+        ".positive": {"color": "bg"},
+        ".negative": {"color": "bg"},
+        ".neutral": {"color": "bg"},
+        ".callout": {"bg": "bg", "border": "accent", "padding": "md", "radius": "full"},
+        ".quote": {"bg": "bg", "padding": "lg", "radius": "full"},
+        ".pullquote": {"bg": "accent", "color": "bg", "padding": "xl"},
+        ".pullquote .body": {"font": "heading", "font-weight": "bold"},
+        ".keypoint": {"bg": "bg_alt", "padding": "md", "radius": "sm", "gap": "xs"},
+        ".stepper": {"gap": "lg"},
+        ".step": {"bg": "accent", "color": "bg", "padding": "sm"},
+        ".timeline": {"gap": "sm"},
+        ".timeline-item": {"bg": "bg_alt", "padding": "sm"},
+        ".chart": {"bg": "bg", "padding": "lg"},
+        ".figure": {"bg": "bg", "padding": "sm"},
+        ".caption": {"font": "caption", "color": "text"},
+        ".source": {"font": "caption", "color": "text_light"},
+        ".note": {"font": "caption", "color": "text_light"},
+    }
+)

--- a/src/paperops/slides/style/sheets/minimal.py
+++ b/src/paperops/slides/style/sheets/minimal.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from paperops.slides.style.stylesheet import StyleSheet
+
+SHEET = StyleSheet(
+    {
+        ".cover": {"padding": "2xl", "align": "center", "bg": "bg"},
+        ".cover title": {
+            "font": "title",
+            "font-weight": "bold",
+            "color": "text",
+            "align": "center",
+        },
+        ".cover subtitle": {"font": "subtitle", "color": "text_mid", "align": "center"},
+        ".title": {"font": "title", "color": "text", "margin-bottom": "xs"},
+        ".subtitle": {"font": "subtitle", "color": "text_mid"},
+        ".heading": {"font": "heading", "color": "text"},
+        ".text": {"font": "body", "color": "text"},
+        ".prose": {"font": "body", "color": "text", "line-height": 1.2},
+        ".card": {"bg": "bg_alt", "padding": "lg", "radius": "sm", "gap": "md"},
+        ".kpi": {"bg": "bg_accent", "padding": "sm", "gap": "xs"},
+        ".label": {"font": "caption", "color": "text_mid"},
+        ".value": {"font": "heading", "color": "text", "font-weight": "bold"},
+        ".delta": {"font": "caption", "color": "accent"},
+        ".positive": {"color": "positive"},
+        ".negative": {"color": "negative"},
+        ".neutral": {"color": "text_mid"},
+        ".callout": {"bg": "bg_alt", "padding": "md", "border": "border"},
+        ".quote": {"bg": "bg_alt", "padding": "lg", "gap": "sm"},
+        ".quote-mark": {"font": "title", "color": "text_mid"},
+        ".badge": {"bg": "accent", "color": "bg", "padding-x": "sm", "padding-y": "xs"},
+        ".step": {"gap": "xs"},
+        ".spacer": {"min-height": "md"},
+        ".image": {"border": "border", "padding": "xs", "bg": "bg_alt"},
+        ".chart": {"bg": "bg_alt", "padding": "md", "border": "border"},
+        ".note": {"color": "text_light"},
+    }
+)

--- a/src/paperops/slides/style/sheets/pitch.py
+++ b/src/paperops/slides/style/sheets/pitch.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from paperops.slides.style.stylesheet import StyleSheet
+
+SHEET = StyleSheet(
+    {
+        ".cover": {"padding": "2xl", "bg": "bg", "align": "center", "gap": "xl"},
+        ".title": {"font": "title", "font-weight": "bold", "color": "text"},
+        ".subtitle": {"font": "subtitle", "color": "text_mid"},
+        ".heading": {"font": "heading", "color": "primary"},
+        ".text": {"font": "body", "line-height": 1.15},
+        ".prose": {"font": "body", "line-height": 1.2},
+        ".card": {"bg": "bg_accent", "padding": "lg", "radius": "md", "gap": "sm"},
+        ".kpi": {"bg": "primary", "color": "bg", "padding": "md", "gap": "xs"},
+        ".kpi .label": {"color": "bg"},
+        ".kpi .value": {"font": "title", "font-weight": "bold"},
+        ".kpi .delta": {"color": "bg"},
+        ".callout": {"bg": "accent", "color": "bg", "padding": "lg", "gap": "sm"},
+        ".quote": {"bg": "accent", "color": "bg", "padding": "xl", "gap": "sm"},
+        ".pullquote": {"bg": "primary", "color": "bg", "padding": "xl"},
+        ".pullquote .body": {"font": "heading"},
+        ".keypoint": {"bg": "bg_alt", "padding": "md", "gap": "xs"},
+        ".stepper": {"gap": "sm", "animate": "fade-in"},
+        ".timeline": {"gap": "sm"},
+        ".timeline-item": {"padding": "sm", "bg": "bg", "border": "border"},
+        ".figure": {"bg": "bg_alt", "padding": "md"},
+        ".caption": {"font": "caption", "color": "text"},
+        ".source": {"font": "caption", "color": "text_mid"},
+        ".note": {"color": "text_mid", "font": "small"},
+    }
+)

--- a/src/paperops/slides/style/sheets/seminar.py
+++ b/src/paperops/slides/style/sheets/seminar.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from paperops.slides.style.stylesheet import StyleSheet
+
+SHEET = StyleSheet(
+    {
+        ".cover": {"padding": "xl", "bg": "bg"},
+        ".title": {"font": "heading", "font-weight": "bold", "color": "text"},
+        ".subtitle": {"font": "subtitle", "color": "text_mid"},
+        ".heading": {"font": "heading", "color": "primary"},
+        ".text": {"font": "body", "line-height": 1.22},
+        ".prose": {"font": "body", "line-height": 1.35},
+        ".card": {"bg": "bg_alt", "padding": "md", "radius": "md", "gap": "xs"},
+        ".kpi": {"bg": "bg_accent", "padding": "md", "gap": "sm", "radius": "sm"},
+        ".label": {"font": "caption", "color": "text_mid"},
+        ".value": {"font": "title", "color": "primary"},
+        ".delta": {"font": "caption", "font-weight": "bold"},
+        ".positive": {"color": "positive"},
+        ".negative": {"color": "negative"},
+        ".neutral": {"color": "text_mid"},
+        ".chart": {"bg": "bg_alt", "padding": "md", "border": "border"},
+        ".grid": {"gap": "md", "cols": "1fr 1fr"},
+        ".stepper": {"gap": "md"},
+        ".step": {"padding": "sm", "bg": "bg_alt"},
+        ".timeline": {"gap": "md"},
+        ".timeline-item": {"padding": "sm", "border-left": ["primary", "sm"]},
+        ".table": {"bg": "bg", "border": "border"},
+        ".figure": {"gap": "xs"},
+        ".caption": {"font": "caption", "color": "text"},
+    }
+)

--- a/src/paperops/slides/style/sheets/whitepaper.py
+++ b/src/paperops/slides/style/sheets/whitepaper.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from paperops.slides.style.stylesheet import StyleSheet
+
+SHEET = StyleSheet(
+    {
+        ".cover": {"padding": "xl", "bg": "bg"},
+        "slide": {"cols": "1fr 1fr", "gap": "xl", "padding": "lg", "bg": "bg"},
+        ".title": {"font": "heading", "font-weight": "bold", "color": "text"},
+        ".subtitle": {"font": "subtitle", "color": "text_mid"},
+        ".heading": {"font": "heading", "color": "text"},
+        ".text": {"font": "body", "line-height": 1.25, "color": "text"},
+        ".prose": {"font": "body", "line-height": 1.25},
+        ".card": {"bg": "bg_alt", "padding": "md", "border": "border", "radius": "sm"},
+        ".kpi": {"bg": "bg_accent", "padding": "sm"},
+        ".table": {"bg": "bg", "padding": "xs", "border": "border"},
+        ".table .heading": {"font-weight": "bold"},
+        ".chart": {"bg": "bg_alt", "padding": "md"},
+        ".figure": {"gap": "sm", "bg": "bg_alt", "padding": "md"},
+        ".caption": {"font": "caption", "color": "text_mid"},
+        ".source": {"font": "caption", "color": "text_light"},
+        ".stepper": {"gap": "sm"},
+        ".timeline-item": {"padding": "sm", "border": "border"},
+        ".note": {"color": "text_mid", "font": "small"},
+    }
+)

--- a/tests/build/test_atomic_codegen_smoke.py
+++ b/tests/build/test_atomic_codegen_smoke.py
@@ -43,4 +43,6 @@ def test_render_all_atomic_components_via_single_deck(tmp_path: Path):
     prs = Presentation(str(out))
     assert len(prs.slides) == 1
     slide = prs.slides[0]
+    assert any(shape.has_chart for shape in slide.shapes)
+    assert any(shape.has_text_frame for shape in slide.shapes)
     assert any(shape.has_table for shape in slide.shapes)

--- a/tests/build/test_atomic_codegen_smoke.py
+++ b/tests/build/test_atomic_codegen_smoke.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pptx import Presentation
+
+from paperops.slides.build import render_json
+
+
+def test_render_all_atomic_components_via_single_deck(tmp_path: Path):
+    payload = {
+        "theme": "minimal",
+        "sheet": "minimal",
+        "slides": [
+            {
+                "type": "slide",
+                "children": [
+                    {"type": "text", "text": "text atom"},
+                    {"type": "heading", "text": "heading atom"},
+                    {"type": "title", "text": "title atom"},
+                    {"type": "subtitle", "text": "subtitle atom"},
+                    {"type": "box", "text": "box atom"},
+                    {"type": "circle", "text": "◯"},
+                    {"type": "line", "text": "line atom"},
+                    {"type": "arrow", "text": "arrow atom"},
+                    {"type": "divider", "props": {"orientation": "horizontal"}},
+                    {"type": "badge", "text": "badge atom"},
+                    {"type": "spacer", "props": {"size": "sm"}},
+                    {"type": "icon", "props": {"name": "spark", "size": "sm"}},
+                    {"type": "svg", "props": {"body": "<svg/>"}},
+                    {"type": "image", "props": {"src": "placeholder.png"}},
+                    {"type": "chart", "props": {"chart_type": "line"}},
+                    {"type": "table", "props": {"headers": ["h1"], "rows": [["v1"]]}},
+                    {"type": "roundedbox", "text": "rounded atom"},
+                ]
+            }
+        ],
+    }
+
+    out = tmp_path / "all-atoms.pptx"
+    render_json(payload, out=out)
+
+    prs = Presentation(str(out))
+    assert len(prs.slides) == 1

--- a/tests/build/test_atomic_codegen_smoke.py
+++ b/tests/build/test_atomic_codegen_smoke.py
@@ -42,3 +42,5 @@ def test_render_all_atomic_components_via_single_deck(tmp_path: Path):
 
     prs = Presentation(str(out))
     assert len(prs.slides) == 1
+    slide = prs.slides[0]
+    assert any(shape.has_table for shape in slide.shapes)

--- a/tests/build/test_pipeline.py
+++ b/tests/build/test_pipeline.py
@@ -7,11 +7,13 @@ from pptx import Presentation
 from paperops.slides.build import (
     autofit_stage,
     codegen_stage,
+    expand_stage,
     layout_stage,
     parse_stage,
     render_json,
     style_stage,
 )
+from paperops.slides.ir.node import Node
 
 
 MINIMAL_RAW_IR = {
@@ -74,6 +76,43 @@ def test_style_stage_attaches_computed_styles_to_nodes():
     assert computed_styles
     first_slide = root.children[0]
     assert hasattr(first_slide, "computed_style")
+
+
+def test_expand_stage_expands_semantic_components():
+    document = parse_stage(MINIMAL_RAW_IR)
+    expanded = expand_stage(document, strict=True)
+    assert any(slide.type == "slide" for slide in expanded)
+    source_types = {
+        child.type
+        for slide in expanded
+        for child in (slide.children or [])
+        if isinstance(child, Node)
+    }
+    assert "kpi" not in source_types
+
+
+def test_render_stage_expands_kpi_into_cards():
+    # Render-time style stage should include semantic expansion.
+    deck = parse_stage(
+        {
+            "theme": "minimal",
+            "slides": [
+                {
+                    "type": "slide",
+                    "children": [
+                        {"type": "kpi", "props": {"label": "DAU", "value": "125k"}},
+                    ],
+                }
+            ],
+        }
+    )
+    styled_root, _ = style_stage(deck, strict=True)
+    first_slide = styled_root.children[0]
+    assert isinstance(first_slide, object)
+    slide_children = getattr(first_slide, "children", [])
+    assert slide_children, "Expanded slide should still carry child nodes"
+    child_types = {child.type for child in slide_children if hasattr(child, "type")}
+    assert "kpi" not in child_types
 
 
 def test_layout_stage_returns_slide_layout_roots():

--- a/tests/build/test_pipeline.py
+++ b/tests/build/test_pipeline.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from pptx import Presentation
 
 from paperops.slides.build import (
@@ -13,6 +14,7 @@ from paperops.slides.build import (
     render_json,
     style_stage,
 )
+from paperops.slides.components.registry import ComponentError
 from paperops.slides.ir.node import Node
 
 
@@ -149,3 +151,43 @@ def test_render_json_stage_wires_the_full_pipeline(tmp_path: Path):
     assert returned == out
     prs = Presentation(str(out))
     assert len(prs.slides) == 2
+
+
+def test_render_json_enforces_semantic_prop_requirements(tmp_path: Path):
+    with pytest.raises(ComponentError, match="MISSING_REQUIRED_PROP"):
+        render_json(
+            {
+                "theme": "minimal",
+                "slides": [
+                    {
+                        "type": "slide",
+                        "children": [{"type": "kpi", "props": {"label": "DAU"}}],
+                    }
+                ],
+            },
+            out=tmp_path / "missing-prop.pptx",
+        )
+
+    with pytest.raises(ComponentError, match="UNKNOWN_PROP"):
+        render_json(
+            {
+                "theme": "minimal",
+                "slides": [
+                    {
+                        "type": "slide",
+                        "children": [
+                            {
+                                "type": "kpi",
+                                "props": {
+                                    "label": "DAU",
+                                    "value": "125k",
+                                    "delta": "+56%",
+                                    "unknown": "x",
+                                },
+                            }
+                        ],
+                    }
+                ],
+            },
+            out=tmp_path / "unknown-prop.pptx",
+        )

--- a/tests/build/test_semantic_render_smoke.py
+++ b/tests/build/test_semantic_render_smoke.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from pptx import Presentation
 from paperops.slides.build import render_json
 
 pytest.importorskip("pptx")
@@ -37,3 +38,20 @@ def test_all_semantic_components_render_in_one_slide(tmp_path: Path) -> None:
     render_json(payload, out=output)
 
     assert output.exists() and output.stat().st_size > 0
+
+
+def test_notes_are_written_to_speaker_notes_not_slide_shapes(tmp_path: Path) -> None:
+    note_text = "Speaker note should never appear in slide body"
+    payload = {
+        "theme": "minimal",
+        "sheet": "minimal",
+        "slides": [{"type": "slide", "children": [{"type": "note", "children": [note_text]}]}],
+    }
+    output = tmp_path / "semantic-note.pptx"
+    render_json(payload, out=output)
+
+    prs = Presentation(str(output))
+    assert len(prs.slides) == 1
+    slide = prs.slides[0]
+    assert note_text in slide.notes_slide.notes_text_frame.text
+    assert all(note_text not in shape.text_frame.text for shape in slide.shapes if hasattr(shape, "text_frame"))

--- a/tests/build/test_semantic_render_smoke.py
+++ b/tests/build/test_semantic_render_smoke.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from paperops.slides.build import render_json
+
+pytest.importorskip("pptx")
+
+
+SEMANTIC_COMPONENTS = [
+    {"type": "card", "children": [{"type": "text", "text": "card body"}]},
+    {"type": "kpi", "props": {"label": "DAU", "value": "125k", "delta": "+56%"}},
+    {"type": "callout", "props": {"kind": "Insight", "text": "Keep signal clean"}},
+    {"type": "quote", "props": {"text": "A good deck is clear.", "author": "Ops Team"}},
+    {"type": "pullquote", "props": {"text": "Visibility drives trust.", "author": "Field notes"}},
+    {"type": "keypoint", "props": {"number": "01", "title": "Start", "body": "Track evidence"}},
+    {
+        "type": "stepper",
+        "props": {"steps": [{"label": "Collect"}, {"label": "Analyze"}]},
+    },
+    {"type": "timeline", "props": {"items": [{"date": "2026-01", "title": "Pilot"}]}},
+    {"type": "figure", "props": {"chart_type": "bar", "caption": "Trend"}},
+    {"type": "caption", "props": {"text": "A tiny caption"}},
+    {"type": "spacer", "props": {"size": "md"}},
+    {"type": "note", "children": ["speaker note"]},
+]
+
+
+def test_all_semantic_components_render_in_one_slide(tmp_path: Path) -> None:
+    payload = {
+        "theme": "minimal",
+        "sheet": "minimal",
+        "slides": [{"type": "slide", "children": SEMANTIC_COMPONENTS}],
+    }
+    output = tmp_path / "semantic-components.pptx"
+    render_json(payload, out=output)
+
+    assert output.exists() and output.stat().st_size > 0

--- a/tests/components/test_semantic_expansion.py
+++ b/tests/components/test_semantic_expansion.py
@@ -75,8 +75,8 @@ def test_all_semantic_components_expand():
 
     for name, raw in cards.items():
         expanded = expand_node(Node.from_dict(raw))
-        if name == "note":
-            assert expanded.type == "note"
+        if name in {"note", "spacer"}:
+            assert expanded.type == name
         else:
             assert expanded.type != name, f"{name} should expand into a different node type"
 
@@ -100,5 +100,5 @@ def test_all_semantic_components_expand():
 
     # card-like nodes should resolve into a box-shaped subtree in at least one level
     card_tree = expand_node(Node.from_dict({"type": "card", "children": [{"type": "text", "text": "x"}]}))
-    box_types = {"box", "_spacer", "text", "icon", "svg", "image", "chart", "note", "table", "line", "arrow", "divider", "card", "callout", "quote", "pullquote", "keypoint", "stepper", "timeline", "figure", "caption"}
+    box_types = {"box", "spacer", "text", "icon", "svg", "image", "chart", "note", "table", "line", "arrow", "divider", "card", "callout", "quote", "pullquote", "keypoint", "stepper", "timeline", "figure", "caption"}
     assert any(isinstance(child, Node) and child.type in box_types for child in card_tree.children or [])

--- a/tests/components/test_semantic_expansion.py
+++ b/tests/components/test_semantic_expansion.py
@@ -36,6 +36,17 @@ def test_missing_required_kpi_prop_raises_mapped_error():
         expand_node(node)
 
 
+def test_kpi_node_merges_default_and_user_classes_without_duplicates():
+    node = Node(
+        type="kpi",
+        class_="value kpi",
+        props={"label": "DAU", "value": "125k"},
+    )
+    expanded = expand_node(node)
+    classes = [token for token in (expanded.class_ or "").split() if token]
+    assert classes == ["card", "kpi", "value"], classes
+
+
 def test_unknown_kpi_prop_raises_mapped_error():
     node = Node(
         type="kpi",

--- a/tests/components/test_semantic_expansion.py
+++ b/tests/components/test_semantic_expansion.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from paperops.slides.components.registry import ComponentError, expand_node, expand_nodes
+from paperops.slides.ir.node import Node
+from paperops.slides.style import get_sheet
+
+
+def _text_nodes(node: Node) -> list[tuple[str, str]]:
+    out: list[tuple[str, str]] = []
+    if node.text:
+        out.append((node.type, node.text))
+    for child in node.children or []:
+        if isinstance(child, Node):
+            out.extend(_text_nodes(child))
+    return out
+
+
+def test_kpi_expands_to_card_with_label_value_delta_text_nodes():
+    node = Node(type="kpi", props={"label": "DAU", "value": "125k", "delta": "+56%"})
+    expanded = expand_nodes([node])[0]
+
+    assert expanded.type == "padding"
+    texts = {value for _type, value in _text_nodes(expanded) if _type == "text"}
+    assert "DAU" in texts
+    assert "125k" in texts
+    assert "+56%" in texts
+
+
+def test_missing_required_kpi_prop_raises_mapped_error():
+    node = Node(type="kpi", props={"label": "DAU"})
+    with pytest.raises(ComponentError, match="MISSING_REQUIRED_PROP"):
+        expand_node(node)
+
+
+def test_unknown_kpi_prop_raises_mapped_error():
+    node = Node(
+        type="kpi",
+        props={"label": "DAU", "value": "125k", "delta": "+56%", "unknown": "x"},
+    )
+    with pytest.raises(ComponentError, match="UNKNOWN_PROP"):
+        expand_node(node)
+
+
+def test_default_class_merges_before_user_class_and_dedupes():
+    expanded = expand_nodes([Node(type="text", class_="body text", props={"text": "Hello"})])[0]
+    assert expanded.class_ == "text body"
+    assert re.fullmatch(r"text\s+body", expanded.class_)
+
+
+def test_builtin_sheet_registry_exposes_default_variants():
+    sheet = get_sheet("minimal")
+    assert sheet is not None
+    assert len(list(sheet)) > 0
+
+
+def test_all_semantic_components_expand():
+    cards = {
+        "card": {"type": "card", "children": [{"type": "text", "text": "body"}]},
+        "kpi": {"type": "kpi", "props": {"label": "DAU", "value": "125k", "delta": "+56%"}},
+        "callout": {"type": "callout", "props": {"kind": "Tip", "text": "Focus on signal"}},
+        "quote": {"type": "quote", "props": {"text": "Stay close to data", "author": "Ops Team"}},
+        "pullquote": {"type": "pullquote", "props": {"text": "This deck is consistent.", "author": "Lead"}},
+        "keypoint": {"type": "keypoint", "props": {"number": "01", "title": "Start", "body": "Collect traces"}},
+        "stepper": {"type": "stepper", "props": {"steps": [{"label": "a"}, {"label": "b"}]}},
+        "timeline": {"type": "timeline", "props": {"items": [{"date": "2026-01", "title": "Pilot"}]}},
+        "figure": {"type": "figure", "props": {"chart_type": "bar", "caption": "Trend"}},
+        "caption": {"type": "caption", "props": {"text": "A tiny caption"}},
+        "spacer": {"type": "spacer", "props": {"size": "sm"}},
+        "note": {"type": "note", "children": ["speaker note line"]},
+    }
+
+    for name, raw in cards.items():
+        expanded = expand_node(Node.from_dict(raw))
+        if name == "note":
+            assert expanded.type == "note"
+        else:
+            assert expanded.type != name, f"{name} should expand into a different node type"
+
+        class_tokens = set((expanded.class_ or "").split())
+        expected = {
+            "card": "card",
+            "kpi": "kpi",
+            "callout": "callout",
+            "quote": "quote",
+            "pullquote": "pullquote",
+            "keypoint": "keypoint",
+            "stepper": "stepper",
+            "timeline": "timeline",
+            "figure": "figure",
+            "caption": "caption",
+            "spacer": "spacer",
+            "note": "note",
+        }.get(name)
+        if expected:
+            assert expected in class_tokens
+
+    # card-like nodes should resolve into a box-shaped subtree in at least one level
+    card_tree = expand_node(Node.from_dict({"type": "card", "children": [{"type": "text", "text": "x"}]}))
+    box_types = {"box", "_spacer", "text", "icon", "svg", "image", "chart", "note", "table", "line", "arrow", "divider", "card", "callout", "quote", "pullquote", "keypoint", "stepper", "timeline", "figure", "caption"}
+    assert any(isinstance(child, Node) and child.type in box_types for child in card_tree.children or [])

--- a/tests/examples/test_gallery_variants.py
+++ b/tests/examples/test_gallery_variants.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from pptx import Presentation
+
+from paperops.slides.build import render_json
+
+
+GALLERY_CONTENT = Path(__file__).resolve().parents[2] / "examples" / "gallery" / "gallery_content.json"
+SHEETS = ["minimal", "academic", "seminar", "keynote", "whitepaper", "pitch"]
+
+
+def _read_content() -> dict:
+    return json.loads(GALLERY_CONTENT.read_text(encoding="utf-8"))
+
+
+def _checksum(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_render_all_sheet_variants_from_gallery_content(tmp_path: Path):
+    base = _read_content()
+    outputs: list[Path] = []
+
+    for sheet in SHEETS:
+        payload = dict(base)
+        payload["sheet"] = sheet
+        out = tmp_path / f"gallery-{sheet}.pptx"
+        render_json(payload, out=out)
+        outputs.append(out)
+
+        prs = Presentation(str(out))
+        assert len(prs.slides) == len(base["slides"])
+
+    hashes = {_checksum(out) for out in outputs}
+    assert len(hashes) == len(outputs), "variant outputs should differ by sheet"

--- a/tests/style/test_sheet_registry.py
+++ b/tests/style/test_sheet_registry.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from paperops.slides.style import list_sheets
+
+
+def test_builtin_sheets_are_registered():
+    sheets = list_sheets()
+    expected = {"default", "minimal", "academic", "seminar", "keynote", "whitepaper", "pitch"}
+    assert expected.issubset(set(sheets))
+    assert len(sheets) >= len(expected)


### PR DESCRIPTION
Phase 3 completion for component system and visual variants.

## Done
- Ensure all atomic components are registry-backed and validated through  via explicit registry module import.
- Added native PPTX chart rendering path ( component) with payload normalization and chart-type mapping.
- Added layout/codegen support for roundedbox as rounded rectangle shape.
- Prevented  nodes from rendering into slide body; notes now flow to speaker notes only.
- Extended tests for pipeline prop validation (missing required / unknown props) and semantic notes behavior.
- Updated component API docs for registry-style props on line/arrow examples.

Related issue: #4