### PR TITLE
Phase 4: MDX / Markdown / Inline HTML authoring DSLs

### DIFF
--- a/src/paperops/slides/build.py
+++ b/src/paperops/slides/build.py
@@ -18,6 +18,8 @@ from paperops.slides.core.constants import CONTENT_REGION, SLIDE_HEIGHT, SLIDE_W
 from paperops.slides.core.theme import Theme, themes
 from paperops.slides.dsl.json_loader import Document
 from paperops.slides.dsl.json_loader import load_json_document
+from paperops.slides.dsl.markdown_parser import load_markdown_document
+from paperops.slides.dsl.mdx_parser import load_mdx_document
 from paperops.slides.layout.engine import build_layout_tree, compute_layout
 from paperops.slides.components.registry import expand_nodes
 from paperops.slides.style import get_sheet, resolve_computed_styles
@@ -53,6 +55,15 @@ def parse_stage(
         return source
     if isinstance(source, Mapping):
         return load_json_document(dict(source), strict=strict)
+
+    path = Path(source)
+    if path.exists() and path.is_file():
+        name = path.name.lower()
+        if name.endswith(".deck.md") or name.endswith(".md"):
+            return load_markdown_document(path)
+        if name.endswith(".slide.mdx") or name.endswith(".deck.mdx") or name.endswith(".mdx"):
+            return load_mdx_document(path)
+
     return load_json_document(source, strict=strict)
 
 

--- a/src/paperops/slides/dsl/__init__.py
+++ b/src/paperops/slides/dsl/__init__.py
@@ -1,6 +1,18 @@
 """DSL entrypoints for slide IR parsing and construction."""
 
 from paperops.slides.dsl.json_loader import Document, DEFAULT_SCHEMA, load_json_document
+from paperops.slides.dsl.markdown_parser import (
+    MarkdownParseError,
+    load_markdown_document,
+    parse_markdown_fragment,
+    parse_markdown_text,
+)
+from paperops.slides.dsl.mdx_parser import (
+    MDXParseError,
+    load_mdx_document,
+    parse_mdx_fragment,
+    parse_mdx_text,
+)
 from paperops.slides.dsl.python_builder import (
     Deck,
     Flex,
@@ -27,10 +39,18 @@ __all__ = [
     "Heading",
     "KPI",
     "load_json_document",
+    "load_markdown_document",
+    "load_mdx_document",
     "Layer",
     "Padding",
     "Slide",
+    "MarkdownParseError",
+    "MDXParseError",
     "Stack",
+    "parse_markdown_fragment",
+    "parse_markdown_text",
+    "parse_mdx_fragment",
+    "parse_mdx_text",
     "Subtitle",
     "Text",
     "Title",

--- a/src/paperops/slides/dsl/inline_html.py
+++ b/src/paperops/slides/dsl/inline_html.py
@@ -1,0 +1,383 @@
+"""Inline HTML filter and run-style extraction used by Markdown/MDX parsers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Any
+
+
+INLINE_HTML_TAGS = {
+    "b",
+    "strong",
+    "i",
+    "em",
+    "u",
+    "s",
+    "del",
+    "sub",
+    "sup",
+    "code",
+    "br",
+    "a",
+    "span",
+    "mark",
+}
+
+# Style keys that may appear on inline <span>.
+SPAN_STYLE_KEYS = {
+    "color",
+    "background-color",
+    "font-weight",
+    "font-style",
+    "text-decoration",
+}
+
+_SPAN_COLOR = re.compile(r"^#[0-9A-Fa-f]{3}([0-9A-Fa-f]{3})?$")
+_RGB_FN = re.compile(
+    r"^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$",
+    re.I,
+)
+_TOKEN = re.compile(r"^[A-Za-z_][A-Za-z0-9_./-]*$")
+
+
+@dataclass(frozen=True)
+class InlineHtmlError(ValueError):
+    """Structured parse-time inline HTML error."""
+
+    code: str
+    message: str
+    path: str = ""
+    suggestion: list[str] | None = None
+
+    def __post_init__(self) -> None:
+        parts = [f"[{self.code}]"]
+        if self.path:
+            parts.append(f"{self.path}:")
+        parts.append(self.message)
+        object.__setattr__(self, "args", (" ".join(parts),))
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "code": self.code,
+            "message": self.message,
+        }
+        if self.path:
+            payload["path"] = self.path
+        if self.suggestion:
+            payload["suggestion"] = list(self.suggestion)
+        return payload
+
+
+@dataclass(frozen=True)
+class ParsedInlineHtml:
+    tag: str
+    attrs: dict[str, Any]
+    content: str
+    self_closing: bool
+    consumed: int
+
+
+def _coerce_scalar(value: str) -> bool | int | float | str:
+    if value.lower() in {"true", "yes", "on"}:
+        return True
+    if value.lower() in {"false", "no", "off"}:
+        return False
+    if re.fullmatch(r"-?\d+", value):
+        try:
+            return int(value)
+        except ValueError:
+            pass
+    try:
+        return float(value)
+    except ValueError:
+        return value
+
+
+def parse_attributes(raw: str, *, path: str = "") -> dict[str, Any]:
+    """Parse HTML attribute payload from a tag.
+
+    Supports a small HTML-like subset:
+    - key="value"
+    - key='value'
+    - key=value
+    - key (boolean)
+    """
+
+    attrs: dict[str, Any] = {}
+    i = 0
+    n = len(raw)
+
+    while i < n:
+        while i < n and raw[i].isspace():
+            i += 1
+        if i >= n:
+            break
+
+        name_start = i
+        while i < n and re.match(r"[A-Za-z0-9_:-]", raw[i]):
+            i += 1
+        name = raw[name_start:i].strip()
+        if not name:
+            i += 1
+            continue
+
+        while i < n and raw[i].isspace():
+            i += 1
+
+        if i >= n or raw[i] != "=":
+            attrs[name] = True
+            continue
+        i += 1
+
+        while i < n and raw[i].isspace():
+            i += 1
+        if i >= n:
+            attrs[name] = ""
+            break
+
+        quote = raw[i]
+        if quote in {'"', "'"}:
+            i += 1
+            value_start = i
+            while i < n:
+                ch = raw[i]
+                if ch == "\\" and i + 1 < n:
+                    i += 2
+                    continue
+                if ch == quote:
+                    break
+                i += 1
+            attrs[name] = _coerce_scalar(raw[value_start:i])
+            if i < n:
+                i += 1
+            continue
+
+        value_start = i
+        while i < n and not raw[i].isspace():
+            i += 1
+        attrs[name] = _coerce_scalar(raw[value_start:i])
+
+    return attrs
+
+
+def parse_style_declarations(raw: str, *, path: str = "") -> dict[str, str]:
+    """Parse a ``style="..."`` declaration block."""
+
+    style: dict[str, str] = {}
+    for chunk in (chunk.strip() for chunk in raw.split(";")):
+        if not chunk:
+            continue
+        if ":" not in chunk:
+            raise InlineHtmlError(
+                "UNSUPPORTED_INLINE_HTML",
+                f"Invalid style declaration {chunk!r}",
+                path=path,
+            )
+        key, value = chunk.split(":", 1)
+        key = key.strip()
+        if key not in SPAN_STYLE_KEYS:
+            raise InlineHtmlError(
+                "UNSUPPORTED_INLINE_HTML",
+                f"Unsupported <span> style property {key!r}",
+                path=path,
+                suggestion=["Allowed: color, background-color, font-weight, font-style, text-decoration"],
+            )
+        style[key] = value.strip()
+    return style
+
+
+def _normalize_style_token(value: str, *, path: str = "") -> str:
+    value = value.strip()
+    if not value:
+        raise InlineHtmlError(
+            "UNSUPPORTED_INLINE_HTML",
+            "Empty inline HTML style value",
+            path=path,
+        )
+    if value.lower() in {"normal", "none", "auto", "inherit"}:
+        return value.lower()
+    if _SPAN_COLOR.fullmatch(value):
+        return value
+    if _RGB_FN.fullmatch(value):
+        return value
+    if _TOKEN.fullmatch(value):
+        return value
+    raise InlineHtmlError(
+        "UNSUPPORTED_INLINE_HTML",
+        f"Unsupported style value {value!r}; use hex/rgb token or theme token",
+        path=path,
+    )
+
+
+def normalize_span_style(raw: dict[str, str], *, path: str = "") -> dict[str, str]:
+    normalized: dict[str, str] = {}
+    for key, value in raw.items():
+        if key in {"color", "background-color"}:
+            normalized[key] = _normalize_style_token(str(value), path=path)
+        else:
+            # Keep CSS keyword-like values unchanged for non-color props.
+            if not _TOKEN.fullmatch(str(value)) and " " not in str(value):
+                # Permit token and simple phrases like "line-through".
+                _normalize_style_token(str(value), path=path)
+            normalized[key] = str(value)
+    return normalized
+
+
+def _find_matching_close(remaining: str, tag: str) -> int | None:
+    close_tag = re.compile(rf"</\s*{re.escape(tag)}\s*>", re.I)
+    pos = close_tag.search(remaining)
+    return pos.start() if pos else None
+
+
+def _consume_matching_close(remaining: str, tag: str, start_offset: int) -> int:
+    close = re.search(rf"</\s*{re.escape(tag)}\s*>", remaining, flags=re.I)
+    if close is None:
+        raise InlineHtmlError(
+            "UNSUPPORTED_INLINE_HTML",
+            f"Missing closing tag for <{tag}>",
+            path="",
+        )
+    return start_offset + close.end()
+
+
+def parse_inline_html(text: str, *, path: str = "", start: int = 0) -> tuple[ParsedInlineHtml | None, int]:
+    """Parse one inline HTML token at ``text[start:]``.
+
+    Returns (element, consumed_chars). If no valid inline HTML starts here,
+    returns (None, 0).
+    """
+
+    if start >= len(text) or text[start] != "<":
+        return None, 0
+
+    # Requirement: < followed by whitespace or digit should stay literal.
+    if start + 1 < len(text) and (text[start + 1].isspace() or text[start + 1].isdigit()):
+        return None, 0
+
+    # Match opening tag and keep raw attribute body.
+    open_match = re.match(r"<\s*([A-Za-z][A-Za-z0-9_-]*)([^>]*)>", text[start:])
+    if not open_match:
+        return None, 0
+
+    tag = open_match.group(1).lower()
+    raw_attrs = (open_match.group(2) or "").rstrip()
+
+    if tag not in INLINE_HTML_TAGS:
+        raise InlineHtmlError(
+            "UNSUPPORTED_INLINE_HTML",
+            f"Unsupported inline HTML tag <{tag}>",
+            path=path,
+            suggestion=["Use fenced div (:::)", "Use a registered MDX component"],
+        )
+
+    is_self_closing = raw_attrs.rstrip().endswith("/")
+    if is_self_closing:
+        raw_attrs = raw_attrs[:-1]
+    attrs = parse_attributes(raw_attrs.strip(), path=path)
+
+    open_end = start + open_match.end()
+
+    if tag == "br":
+        if is_self_closing:
+            return ParsedInlineHtml(
+                tag="br",
+                attrs=attrs,
+                content="",
+                self_closing=True,
+                consumed=open_match.end(),
+            ), open_match.end()
+        # Accept paired <br>...</br> as an alias.
+        consumed = _consume_matching_close(text[start:], tag=tag, start_offset=start) - start
+        return ParsedInlineHtml(
+            tag="br",
+            attrs=attrs,
+            content="",
+            self_closing=False,
+            consumed=consumed,
+        ), consumed
+
+    if is_self_closing:
+        raise InlineHtmlError(
+            "UNSUPPORTED_INLINE_HTML",
+            f"<{tag}> cannot be self-closing",
+            path=path,
+        )
+
+    close = re.search(rf"</\s*{re.escape(tag)}\s*>", text[open_end:], flags=re.I)
+    if close is None:
+        raise InlineHtmlError(
+            "UNSUPPORTED_INLINE_HTML",
+            f"Missing closing tag for <{tag}>",
+            path=path,
+        )
+
+    content = text[open_end : open_end + close.start()]
+    consumed = open_match.end() + close.end()
+
+    if tag == "a" and "href" not in attrs:
+        raise InlineHtmlError(
+            "UNSUPPORTED_INLINE_HTML",
+            "<a> requires href attribute",
+            path=path,
+        )
+
+    if tag == "span" and "style" in attrs:
+        style_value = attrs["style"]
+        if not isinstance(style_value, str):
+            raise InlineHtmlError(
+                "UNSUPPORTED_INLINE_HTML",
+                "<span> style must be a string",
+                path=path,
+            )
+        attrs["style"] = normalize_span_style(parse_style_declarations(style_value, path=path), path=path)
+
+    return ParsedInlineHtml(
+        tag=tag,
+        attrs=attrs,
+        content=content,
+        self_closing=False,
+        consumed=consumed,
+    ), start + consumed
+
+
+def run_style_overrides(tag: str, attrs: dict[str, Any]) -> dict[str, Any]:
+    """Map inline tag + attributes into text run style overrides."""
+
+    overrides: dict[str, Any] = {}
+
+    if tag in {"b", "strong"}:
+        overrides["bold"] = True
+    elif tag in {"i", "em"}:
+        overrides["italic"] = True
+    elif tag == "u":
+        overrides["underline"] = True
+    elif tag in {"s", "del"}:
+        overrides["strike"] = True
+    elif tag == "sub":
+        overrides["vertAlign"] = "sub"
+    elif tag == "sup":
+        overrides["vertAlign"] = "sup"
+    elif tag == "code":
+        overrides["font_family"] = "font_mono"
+    elif tag == "mark":
+        overrides["highlight"] = True
+    elif tag == "a":
+        href = attrs.get("href")
+        if href is not None:
+            overrides["href"] = str(href)
+    elif tag == "span":
+        style = attrs.get("style")
+        if isinstance(style, dict):
+            if "color" in style:
+                overrides["color"] = style["color"]
+            if "background-color" in style:
+                overrides["background_color"] = style["background-color"]
+            if "font-weight" in style:
+                overrides["font_weight"] = style["font-weight"]
+            if "font-style" in style:
+                overrides["font_style"] = style["font-style"]
+            if "text-decoration" in style:
+                overrides["text_decoration"] = style["text-decoration"]
+
+    return overrides

--- a/src/paperops/slides/dsl/inline_html.py
+++ b/src/paperops/slides/dsl/inline_html.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import re
+from dataclasses import dataclass
 from typing import Any
-
 
 INLINE_HTML_TAGS = {
     "b",
@@ -41,7 +40,7 @@ _RGB_FN = re.compile(
 _TOKEN = re.compile(r"^[A-Za-z_][A-Za-z0-9_./-]*$")
 
 
-@dataclass(frozen=True)
+@dataclass
 class InlineHtmlError(ValueError):
     """Structured parse-time inline HTML error."""
 
@@ -55,7 +54,7 @@ class InlineHtmlError(ValueError):
         if self.path:
             parts.append(f"{self.path}:")
         parts.append(self.message)
-        object.__setattr__(self, "args", (" ".join(parts),))
+        self.args = (" ".join(parts),)
 
     def to_dict(self) -> dict[str, Any]:
         payload: dict[str, Any] = {
@@ -181,7 +180,9 @@ def parse_style_declarations(raw: str, *, path: str = "") -> dict[str, str]:
                 "UNSUPPORTED_INLINE_HTML",
                 f"Unsupported <span> style property {key!r}",
                 path=path,
-                suggestion=["Allowed: color, background-color, font-weight, font-style, text-decoration"],
+                suggestion=[
+                    "Allowed: color, background-color, font-weight, font-style, text-decoration"
+                ],
             )
         style[key] = value.strip()
     return style
@@ -241,7 +242,9 @@ def _consume_matching_close(remaining: str, tag: str, start_offset: int) -> int:
     return start_offset + close.end()
 
 
-def parse_inline_html(text: str, *, path: str = "", start: int = 0) -> tuple[ParsedInlineHtml | None, int]:
+def parse_inline_html(
+    text: str, *, path: str = "", start: int = 0
+) -> tuple[ParsedInlineHtml | None, int]:
     """Parse one inline HTML token at ``text[start:]``.
 
     Returns (element, consumed_chars). If no valid inline HTML starts here,
@@ -252,7 +255,9 @@ def parse_inline_html(text: str, *, path: str = "", start: int = 0) -> tuple[Par
         return None, 0
 
     # Requirement: < followed by whitespace or digit should stay literal.
-    if start + 1 < len(text) and (text[start + 1].isspace() or text[start + 1].isdigit()):
+    if start + 1 < len(text) and (
+        text[start + 1].isspace() or text[start + 1].isdigit()
+    ):
         return None, 0
 
     # Match opening tag and keep raw attribute body.
@@ -280,22 +285,30 @@ def parse_inline_html(text: str, *, path: str = "", start: int = 0) -> tuple[Par
 
     if tag == "br":
         if is_self_closing:
-            return ParsedInlineHtml(
+            return (
+                ParsedInlineHtml(
+                    tag="br",
+                    attrs=attrs,
+                    content="",
+                    self_closing=True,
+                    consumed=open_match.end(),
+                ),
+                open_match.end(),
+            )
+        # Accept paired <br>...</br> as an alias.
+        consumed = (
+            _consume_matching_close(text[start:], tag=tag, start_offset=start) - start
+        )
+        return (
+            ParsedInlineHtml(
                 tag="br",
                 attrs=attrs,
                 content="",
-                self_closing=True,
-                consumed=open_match.end(),
-            ), open_match.end()
-        # Accept paired <br>...</br> as an alias.
-        consumed = _consume_matching_close(text[start:], tag=tag, start_offset=start) - start
-        return ParsedInlineHtml(
-            tag="br",
-            attrs=attrs,
-            content="",
-            self_closing=False,
-            consumed=consumed,
-        ), consumed
+                self_closing=False,
+                consumed=consumed,
+            ),
+            consumed,
+        )
 
     if is_self_closing:
         raise InlineHtmlError(
@@ -330,15 +343,20 @@ def parse_inline_html(text: str, *, path: str = "", start: int = 0) -> tuple[Par
                 "<span> style must be a string",
                 path=path,
             )
-        attrs["style"] = normalize_span_style(parse_style_declarations(style_value, path=path), path=path)
+        attrs["style"] = normalize_span_style(
+            parse_style_declarations(style_value, path=path), path=path
+        )
 
-    return ParsedInlineHtml(
-        tag=tag,
-        attrs=attrs,
-        content=content,
-        self_closing=False,
-        consumed=consumed,
-    ), start + consumed
+    return (
+        ParsedInlineHtml(
+            tag=tag,
+            attrs=attrs,
+            content=content,
+            self_closing=False,
+            consumed=consumed,
+        ),
+        start + consumed,
+    )
 
 
 def run_style_overrides(tag: str, attrs: dict[str, Any]) -> dict[str, Any]:

--- a/src/paperops/slides/dsl/markdown_parser.py
+++ b/src/paperops/slides/dsl/markdown_parser.py
@@ -1,0 +1,760 @@
+"""Markdown + frontmatter + inline HTML parser for the slide authoring DSL."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+from typing import Any
+
+from paperops.slides.dsl.inline_html import parse_inline_html
+from paperops.slides.dsl.json_loader import DEFAULT_SCHEMA, Document
+from paperops.slides.ir.node import Node
+
+
+@dataclass(frozen=True)
+class MarkdownParseError(ValueError):
+    code: str
+    path: str
+    message: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "args", (f"[{self.code}] {self.path}: {self.message}",))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "code": self.code,
+            "path": self.path,
+            "message": self.message,
+        }
+
+
+_FRONT_MATTER_DELIM = "---"
+_SLIDE_SEPARATOR = "---"
+
+_ATTR_BLOCK_RE = re.compile(r"^\{(.*)\}$")
+_HEADING_RE = re.compile(r"^(?P<hash>#{1,6})\s+(?P<body>.+)$")
+_FENCE_OPEN_RE = re.compile(r"^(?P<marker>:{3,})(?P<rest>.*)$")
+_LIST_RE = re.compile(r"^(?P<indent>\s*)(?P<marker>(?:-|\*|\+|\d+\.))\s+(?P<text>.*)$")
+
+
+def _coerce_scalar(raw: str) -> Any:
+    value = raw.strip()
+    if not value:
+        return ""
+
+    lower = value.lower()
+    if lower in {"null", "none"}:
+        return None
+    if lower in {"true", "on", "yes"}:
+        return True
+    if lower in {"false", "off", "no"}:
+        return False
+
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"\"", "'"}:
+        return value[1:-1]
+
+    if re.fullmatch(r"-?\d+", value):
+        try:
+            return int(value)
+        except ValueError:
+            pass
+    try:
+        return float(value)
+    except ValueError:
+        return value
+
+
+def _parse_frontmatter_block(
+    lines: list[str],
+    base_indent: int = 0,
+) -> tuple[dict[str, Any], int]:
+    data: dict[str, Any] = {}
+    i = 0
+
+    while i < len(lines):
+        raw_line = lines[i]
+        if not raw_line.strip():
+            i += 1
+            continue
+
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        if indent < base_indent:
+            break
+
+        stripped = raw_line.strip()
+        if ":" not in stripped:
+            i += 1
+            continue
+
+        key, value_part = stripped.split(":", 1)
+        key = key.strip()
+        i += 1
+        if not key:
+            continue
+
+        value_part = value_part.strip()
+        if value_part:
+            data[key] = _coerce_scalar(value_part)
+            continue
+
+        nested_lines: list[str] = []
+        while i < len(lines):
+            candidate = lines[i]
+            nested_indent = len(candidate) - len(candidate.lstrip(" "))
+            if not candidate.strip() and nested_indent <= indent:
+                break
+            if nested_indent <= indent:
+                break
+            nested_lines.append(candidate)
+            i += 1
+
+        if not nested_lines:
+            data[key] = {}
+            continue
+
+        is_list = any(item.lstrip().startswith("-") for item in nested_lines)
+        if is_list:
+            values: list[Any] = []
+            for nested_line in nested_lines:
+                text = nested_line.strip()
+                if not text.startswith("-"):
+                    continue
+                raw_value = text[1:].strip()
+                if raw_value:
+                    values.append(_coerce_scalar(raw_value))
+            data[key] = values
+            continue
+
+        nested, _ = _parse_frontmatter_block(nested_lines, base_indent=indent + 2)
+        data[key] = nested
+
+    return data, i
+
+
+def _parse_frontmatter(source: str) -> tuple[dict[str, Any], str]:
+    lines = source.splitlines()
+    if not lines or lines[0].strip() != _FRONT_MATTER_DELIM:
+        return {}, source
+
+    end = None
+    for index in range(1, len(lines)):
+        if lines[index].strip() == _FRONT_MATTER_DELIM:
+            end = index
+            break
+    if end is None:
+        return {}, source
+
+    metadata, _ = _parse_frontmatter_block(lines[1:end], base_indent=0)
+    return metadata, "\n".join(lines[end + 1 :])
+
+
+def _tokenize_attr_tokens(raw: str) -> list[str]:
+    tokens: list[str] = []
+    buffer: list[str] = []
+    i = 0
+    n = len(raw)
+    quote: str | None = None
+    brace = 0
+
+    while i < n:
+        ch = raw[i]
+
+        if quote is None and ch in {"'", '"'}:
+            quote = ch
+            buffer.append(ch)
+            i += 1
+            continue
+        if quote == ch:
+            quote = None
+            buffer.append(ch)
+            i += 1
+            continue
+
+        if quote is None and ch == "{":
+            brace += 1
+            buffer.append(ch)
+            i += 1
+            continue
+        if quote is None and ch == "}" and brace > 0:
+            brace -= 1
+            buffer.append(ch)
+            i += 1
+            continue
+
+        if quote is None and brace == 0 and ch.isspace():
+            token = "".join(buffer).strip()
+            if token:
+                tokens.append(token)
+            buffer = []
+            i += 1
+            continue
+
+        buffer.append(ch)
+        i += 1
+
+    tail = "".join(buffer).strip()
+    if tail:
+        tokens.append(tail)
+    return tokens
+
+
+def _parse_attribute_block(raw: str) -> tuple[str | None, str | None, dict[str, Any]]:
+    match = _ATTR_BLOCK_RE.match(raw.strip())
+    if not match:
+        return None, None, {}
+
+    body = match.group(1).strip()
+    if not body:
+        return None, None, {}
+
+    class_names: list[str] = []
+    node_id: str | None = None
+    style: dict[str, Any] = {}
+
+    for token in _tokenize_attr_tokens(body):
+        if token.startswith("."):
+            if token[1:]:
+                class_names.append(token[1:])
+            continue
+        if token.startswith("#"):
+            node_id = token[1:]
+            continue
+        if "=" in token:
+            key, value = token.split("=", 1)
+            key = key.strip()
+            if key:
+                value = value.strip()
+                if (
+                    (value.startswith('"') and value.endswith('"'))
+                    or (value.startswith("'") and value.endswith("'"))
+                ):
+                    value = value[1:-1]
+                style[key] = _coerce_scalar(value)
+            continue
+        if token:
+            class_names.append(token)
+
+    return (" ".join(filter(None, class_names)) or None), node_id, style
+
+
+def _split_trailing_attributes(text: str) -> tuple[str, str | None]:
+    if not text.rstrip().endswith("}"):
+        return text, None
+    open_index = text.rfind("{")
+    if open_index < 0:
+        return text, None
+    possible = text[open_index:].strip()
+    if "}" not in possible:
+        return text, None
+    return text[:open_index].rstrip(), possible
+
+
+def _has_markup(runs: list[str | Node]) -> bool:
+    return any(isinstance(item, Node) for item in runs)
+
+
+def _parse_fence_open(line: str) -> tuple[int, str | None, str | None, dict[str, Any]]:
+    match = _FENCE_OPEN_RE.match(line)
+    if not match:
+        return 0, None, None, {}
+
+    marker = match.group("marker")
+    raw_rest = match.group("rest").strip()
+    if not marker:
+        return 0, None, None, {}
+
+    node_type: str | None = "prose"
+    class_name: str | None = None
+    style: dict[str, Any] = {}
+
+    if not raw_rest:
+        return len(marker), node_type, class_name, style
+
+    if raw_rest.startswith("{"):
+        if not raw_rest.endswith("}"):
+            raise MarkdownParseError(
+                "INVALID_SYNTAX",
+                "markdown",
+                f"Invalid fenced div attribute block: {line!r}",
+            )
+        class_name, _, style = _parse_attribute_block(raw_rest)
+        return len(marker), node_type, class_name, style
+
+    attr_part = ""
+    token_part = raw_rest
+    if "{" in raw_rest and raw_rest.rstrip().endswith("}"):
+        index = raw_rest.find("{")
+        token_part = raw_rest[:index].strip()
+        attr_part = raw_rest[index:].strip()
+
+    if token_part:
+        if (
+            token_part.startswith(".")
+            or token_part.startswith("#")
+            or "=" in token_part
+            or " " in token_part
+        ):
+            parsed_class, _, parsed_style = _parse_attribute_block("{" + token_part + "}")
+            class_name = parsed_class
+            style.update(parsed_style)
+        else:
+            head, *tail = token_part.split(".")
+            if head:
+                node_type = head
+            if tail:
+                class_name = " ".join(part for part in tail if part)
+
+    if attr_part:
+        parsed_class, _, parsed_style = _parse_attribute_block(attr_part)
+        if parsed_class:
+            class_name = ((class_name or "") + " " + parsed_class).strip() or None
+        style.update(parsed_style)
+
+    return len(marker), node_type, class_name, style
+
+
+def _is_fence_close(line: str, marker_len: int) -> bool:
+    stripped = line.strip()
+    return len(stripped) >= marker_len and len(stripped) <= marker_len and all(ch == ":" for ch in stripped)
+
+
+def _parse_fenced_block(
+    lines: list[str],
+    start: int,
+    *,
+    path: str,
+    stop_fence: int,
+) -> tuple[Node, int]:
+    marker_len, node_type, node_class, style = _parse_fence_open(lines[start])
+    if marker_len == 0 or node_type is None:
+        raise MarkdownParseError(
+            "INVALID_SYNTAX",
+            path,
+            f"Invalid fenced block: {lines[start]!r}",
+        )
+
+    children, next_index = _parse_block_nodes(
+        lines,
+        start + 1,
+        path=path,
+        allow_slide_sep=False,
+        stop_fence=marker_len,
+    )
+    if next_index >= len(lines) or not _is_fence_close(lines[next_index], stop_fence):
+        raise MarkdownParseError(
+            "INVALID_SYNTAX",
+            path,
+            f"Unclosed fenced block: {lines[start]!r}",
+        )
+
+    return (
+        Node(
+            type=node_type,
+            class_=node_class,
+            style=style or None,
+            children=children or None,
+        ),
+        next_index + 1,
+    )
+
+
+def _merge_adjacent_text_nodes(items: list[str | Node]) -> list[str | Node]:
+    merged: list[str | Node] = []
+    for item in items:
+        if isinstance(item, str) and merged and isinstance(merged[-1], str):
+            merged[-1] = merged[-1] + item
+        else:
+            merged.append(item)
+    return merged
+
+
+def _parse_inline_runs(text: str, *, path: str) -> list[str | Node]:
+    out: list[str | Node] = []
+    i = 0
+    n = len(text)
+
+    while i < n:
+        ch = text[i]
+        if ch == "\\" and i + 1 < n:
+            out.append(text[i + 1])
+            i += 2
+            continue
+
+        if text.startswith("**", i):
+            close = text.find("**", i + 2)
+            if close >= 0:
+                inner = _parse_inline_runs(text[i + 2 : close], path=path)
+                out.append(Node(type="strong", children=inner if inner else []))
+                i = close + 2
+                continue
+            out.append("**")
+            i += 2
+            continue
+
+        if text.startswith("*", i):
+            close = text.find("*", i + 1)
+            if close >= 0:
+                inner = _parse_inline_runs(text[i + 1 : close], path=path)
+                out.append(Node(type="em", children=inner if inner else []))
+                i = close + 1
+                continue
+            out.append("*")
+            i += 1
+            continue
+
+        if text.startswith("`", i):
+            close = text.find("`", i + 1)
+            if close >= 0:
+                code_text = text[i + 1 : close]
+                out.append(Node(type="code", children=[code_text]))
+                i = close + 1
+                continue
+            out.append("`")
+            i += 1
+            continue
+
+        if ch == "<":
+            parsed, consumed = parse_inline_html(text, path=path, start=i)
+            if parsed is not None:
+                if parsed.tag == "br" and parsed.attrs == {}:
+                    out.append(Node(type="br", props={}, children=[]))
+                    i = consumed
+                    continue
+
+                child_runs = (
+                    _parse_inline_runs(parsed.content, path=path) if parsed.content else []
+                )
+                out.append(Node(type=parsed.tag, props=parsed.attrs, children=child_runs))
+                i = consumed
+                continue
+
+            out.append(ch)
+            i += 1
+            continue
+
+        out.append(ch)
+        i += 1
+
+    return _merge_adjacent_text_nodes(out)
+
+
+def _has_only_text(nodes: list[str | Node] | None) -> bool:
+    if not nodes:
+        return False
+    return all(isinstance(item, str) for item in nodes)
+
+
+def _extract_text(nodes: list[str | Node] | None) -> str:
+    if not nodes:
+        return ""
+
+    parts: list[str] = []
+    for item in nodes:
+        if isinstance(item, str):
+            parts.append(item)
+        else:
+            if item.text is not None:
+                parts.append(item.text)
+            parts.extend([_extract_text(list(item.children or []))])
+    return "".join(parts)
+
+
+def _apply_node_attributes(
+    node: Node,
+    class_name: str | None,
+    node_id: str | None,
+    style: dict[str, Any],
+) -> Node:
+    merged_class = node.class_
+    if class_name is not None:
+        merged = (merged_class or "").split()
+        for token in class_name.split():
+            if token and token not in merged:
+                merged.append(token)
+        merged_class = " ".join(merged).strip() or None
+
+    merged_style = dict(node.style or {})
+    merged_style.update(style)
+    return Node(
+        type=node.type,
+        class_=merged_class,
+        id=node_id if node_id is not None else node.id,
+        style=merged_style or None,
+        text=node.text,
+        props=node.props,
+        children=node.children,
+    )
+
+
+def _parse_heading(line: str, path: str) -> tuple[Node, int]:
+    match = _HEADING_RE.match(line)
+    if not match:
+        raise MarkdownParseError("INVALID_SYNTAX", path, f"Invalid heading: {line!r}")
+
+    level = len(match.group("hash"))
+    body = match.group("body")
+    body, attr = _split_trailing_attributes(body)
+    class_name = None
+    node_id = None
+    style: dict[str, Any] = {}
+    if attr is not None:
+        class_name, node_id, style = _parse_attribute_block(attr)
+
+    node_type = "title" if level == 1 else "heading"
+    runs = _parse_inline_runs(body, path=path)
+    text = _extract_text(runs)
+    children: list[str | Node] | None = None
+    if _has_only_text(runs):
+        runs = None
+        children = None
+    else:
+        children = runs
+    return (
+        _apply_node_attributes(
+            Node(
+                type=node_type,
+                text=text,
+                class_=class_name,
+                id=node_id,
+                style=style or None,
+                children=children,
+            ),
+            class_name,
+            node_id,
+            style,
+        ),
+        1,
+    )
+
+
+def _parse_list_block(lines: list[str], start: int, *, path: str) -> tuple[Node, int]:
+    i = start
+    first = _LIST_RE.match(lines[i])
+    if not first:
+        raise MarkdownParseError("INVALID_SYNTAX", path, f"Invalid list block: {lines[i]!r}")
+
+    base_indent = len(first.group("indent"))
+    items: list[Node] = []
+
+    while i < len(lines):
+        current = _LIST_RE.match(lines[i])
+        if not current:
+            break
+        if len(current.group("indent")) != base_indent:
+            break
+
+        marker = current.group("marker")
+        if marker.endswith("."):
+            _ = marker
+
+        raw = current.group("text")
+        item_runs = _parse_inline_runs(raw, path=path)
+        item_text = _extract_text(item_runs)
+        item_children = item_runs if _has_markup(item_runs) else None
+        items.append(Node(type="prose", text=item_text, children=item_children))
+        i += 1
+
+    return Node(type="list", children=items), i
+
+
+def _parse_paragraph(lines: list[str], start: int, *, path: str) -> tuple[Node, int]:
+    raw_lines: list[str] = []
+    i = start
+
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+        if not stripped:
+            break
+        if stripped == _SLIDE_SEPARATOR:
+            break
+        if _FENCE_OPEN_RE.match(line):
+            break
+        if _HEADING_RE.match(stripped):
+            break
+        if _LIST_RE.match(line):
+            break
+        if stripped.startswith("{") and _ATTR_BLOCK_RE.match(stripped):
+            break
+
+        if stripped.startswith(">"):
+            raw_lines.append(stripped.lstrip("> ").lstrip(">"))
+        else:
+            raw_lines.append(line.rstrip())
+        i += 1
+
+    paragraph_text = " ".join(item.strip() for item in raw_lines).strip()
+    if not paragraph_text:
+        return Node(type="prose", text="", children=None), i
+
+    runs = _parse_inline_runs(paragraph_text, path=path)
+    text = _extract_text(runs)
+    children: list[str | Node] | None = runs if _has_markup(runs) else None
+    return Node(type="prose", text=text, children=children), i
+
+
+def _is_paragraph_attribute(line: str) -> bool:
+    return bool(_ATTR_BLOCK_RE.match(line))
+
+
+def _parse_block_nodes(
+    lines: list[str],
+    start: int,
+    *,
+    path: str,
+    allow_slide_sep: bool,
+    stop_fence: int | None = None,
+) -> tuple[list[Node], int]:
+    nodes: list[Node] = []
+    i = start
+
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+
+        if stop_fence is not None and _is_fence_close(line, stop_fence):
+            break
+        if not stripped:
+            i += 1
+            continue
+        if allow_slide_sep and stripped == _SLIDE_SEPARATOR:
+            break
+
+        if _FENCE_OPEN_RE.match(line):
+            marker_len, _node_type, _class_name, _style = _parse_fence_open(line)
+            if marker_len:
+                node, i = _parse_fenced_block(
+                    lines,
+                    i,
+                    path=path,
+                    stop_fence=marker_len,
+                )
+                nodes.append(node)
+                continue
+
+        if _HEADING_RE.match(stripped):
+            node, consumed = _parse_heading(stripped, path=f"{path}[{i}]")
+            nodes.append(node)
+            i += consumed
+            continue
+
+        if _LIST_RE.match(line):
+            node, i = _parse_list_block(lines, i, path=f"{path}[{i}]")
+            nodes.append(node)
+            continue
+
+        if _is_paragraph_attribute(stripped) and nodes:
+            class_name, node_id, style = _parse_attribute_block(stripped)
+            nodes[-1] = _apply_node_attributes(nodes[-1], class_name, node_id, style)
+            i += 1
+            continue
+
+        node, i = _parse_paragraph(lines, i, path=f"{path}[{i}]")
+        if node.text is not None or node.children is not None:
+            nodes.append(node)
+
+    return nodes, i
+
+
+def parse_markdown_fragment(source: str, *, path: str = "markdown") -> list[Node]:
+    nodes, _ = _parse_block_nodes(
+        source.splitlines(),
+        0,
+        path=path,
+        allow_slide_sep=False,
+    )
+    return nodes
+
+
+def parse_markdown_text(
+    source: str,
+    *,
+    path: str = "markdown",
+    parse_front_matter: bool = True,
+) -> tuple[Document, dict[str, Any]]:
+    metadata: dict[str, Any] = {}
+    body = source
+    if parse_front_matter:
+        metadata, body = _parse_frontmatter(source)
+
+    frontmatter = {
+        key: metadata[key]
+        for key in ["theme", "sheet", "meta", "styles", "defines", "$schema"]
+        if key in metadata
+    }
+    metadata_rest = {key: value for key, value in metadata.items() if key not in frontmatter}
+
+    lines = body.splitlines()
+    slides: list[list[Node]] = [[]]
+    i = 0
+    while i < len(lines):
+        line = lines[i].strip()
+        if line == _SLIDE_SEPARATOR:
+            if slides and slides[-1] != []:
+                slides.append([])
+            else:
+                slides.append([])
+            i += 1
+            continue
+
+        block_nodes, i = _parse_block_nodes(
+            lines,
+            i,
+            path=path,
+            allow_slide_sep=True,
+        )
+        if block_nodes:
+            slides[-1].extend(block_nodes)
+
+    while slides and slides[-1] == [] and len(slides) > 1:
+        slides.pop()
+    if not slides:
+        slides = [[]]
+
+    payload: dict[str, Any] = {
+        "$schema": frontmatter.get("$schema", DEFAULT_SCHEMA),
+        "theme": frontmatter.get("theme", "minimal"),
+        "slides": [
+            {"type": "slide", "children": [node.to_dict() for node in nodes]}
+            for nodes in slides
+        ],
+    }
+    if "sheet" in frontmatter:
+        payload["sheet"] = frontmatter["sheet"]
+    if "styles" in frontmatter:
+        payload["styles"] = frontmatter["styles"]
+    if "defines" in frontmatter:
+        payload["defines"] = frontmatter["defines"]
+    if "meta" in frontmatter:
+        payload["meta"] = frontmatter["meta"]
+
+    return Document.from_dict(payload), metadata_rest
+
+
+def to_canonical_ir(source: str | Path) -> Document:
+    return parse_markdown_text(
+        Path(source).read_text(encoding="utf-8") if isinstance(source, Path) else str(source),
+        path=str(source),
+    )[0]
+
+
+def load_markdown_document(source: str | Path) -> Document:
+    if isinstance(source, Path):
+        text = source.read_text(encoding="utf-8")
+        path = str(source)
+    else:
+        text = str(source)
+        path = "<memory>"
+
+    document, _ = parse_markdown_text(text, path=path, parse_front_matter=True)
+    return document
+
+
+__all__ = [
+    "MarkdownParseError",
+    "load_markdown_document",
+    "parse_markdown_fragment",
+    "parse_markdown_text",
+    "to_canonical_ir",
+]

--- a/src/paperops/slides/dsl/markdown_parser.py
+++ b/src/paperops/slides/dsl/markdown_parser.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from pathlib import Path
-import re
 from typing import Any
 
 from paperops.slides.dsl.inline_html import parse_inline_html
@@ -12,14 +12,14 @@ from paperops.slides.dsl.json_loader import DEFAULT_SCHEMA, Document
 from paperops.slides.ir.node import Node
 
 
-@dataclass(frozen=True)
+@dataclass
 class MarkdownParseError(ValueError):
     code: str
     path: str
     message: str
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "args", (f"[{self.code}] {self.path}: {self.message}",))
+        self.args = (f"[{self.code}] {self.path}: {self.message}",)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -38,6 +38,23 @@ _FENCE_OPEN_RE = re.compile(r"^(?P<marker>:{3,})(?P<rest>.*)$")
 _LIST_RE = re.compile(r"^(?P<indent>\s*)(?P<marker>(?:-|\*|\+|\d+\.))\s+(?P<text>.*)$")
 
 
+def _load_source_text(
+    source: str | Path,
+    *,
+    fallback_path: str = "markdown",
+) -> tuple[str, str]:
+    if isinstance(source, Path):
+        return source.read_text(encoding="utf-8"), str(source)
+
+    if isinstance(source, str):
+        candidate = Path(source)
+        if candidate.exists():
+            return candidate.read_text(encoding="utf-8"), str(candidate)
+        return source, fallback_path
+
+    raise TypeError(f"Unsupported source type: {type(source)!r}")
+
+
 def _coerce_scalar(raw: str) -> Any:
     value = raw.strip()
     if not value:
@@ -51,7 +68,7 @@ def _coerce_scalar(raw: str) -> Any:
     if lower in {"false", "off", "no"}:
         return False
 
-    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"\"", "'"}:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
         return value[1:-1]
 
     if re.fullmatch(r"-?\d+", value):
@@ -225,9 +242,8 @@ def _parse_attribute_block(raw: str) -> tuple[str | None, str | None, dict[str, 
             key = key.strip()
             if key:
                 value = value.strip()
-                if (
-                    (value.startswith('"') and value.endswith('"'))
-                    or (value.startswith("'") and value.endswith("'"))
+                if (value.startswith('"') and value.endswith('"')) or (
+                    value.startswith("'") and value.endswith("'")
                 ):
                     value = value[1:-1]
                 style[key] = _coerce_scalar(value)
@@ -295,7 +311,9 @@ def _parse_fence_open(line: str) -> tuple[int, str | None, str | None, dict[str,
             or "=" in token_part
             or " " in token_part
         ):
-            parsed_class, _, parsed_style = _parse_attribute_block("{" + token_part + "}")
+            parsed_class, _, parsed_style = _parse_attribute_block(
+                "{" + token_part + "}"
+            )
             class_name = parsed_class
             style.update(parsed_style)
         else:
@@ -316,7 +334,9 @@ def _parse_fence_open(line: str) -> tuple[int, str | None, str | None, dict[str,
 
 def _is_fence_close(line: str, marker_len: int) -> bool:
     stripped = line.strip()
-    return len(stripped) >= marker_len and len(stripped) <= marker_len and all(ch == ":" for ch in stripped)
+    if len(stripped) < marker_len:
+        return False
+    return bool(stripped) and all(ch == ":" for ch in stripped)
 
 
 def _parse_fenced_block(
@@ -423,9 +443,13 @@ def _parse_inline_runs(text: str, *, path: str) -> list[str | Node]:
                     continue
 
                 child_runs = (
-                    _parse_inline_runs(parsed.content, path=path) if parsed.content else []
+                    _parse_inline_runs(parsed.content, path=path)
+                    if parsed.content
+                    else []
                 )
-                out.append(Node(type=parsed.tag, props=parsed.attrs, children=child_runs))
+                out.append(
+                    Node(type=parsed.tag, props=parsed.attrs, children=child_runs)
+                )
                 i = consumed
                 continue
 
@@ -532,7 +556,9 @@ def _parse_list_block(lines: list[str], start: int, *, path: str) -> tuple[Node,
     i = start
     first = _LIST_RE.match(lines[i])
     if not first:
-        raise MarkdownParseError("INVALID_SYNTAX", path, f"Invalid list block: {lines[i]!r}")
+        raise MarkdownParseError(
+            "INVALID_SYNTAX", path, f"Invalid list block: {lines[i]!r}"
+        )
 
     base_indent = len(first.group("indent"))
     items: list[Node] = []
@@ -650,9 +676,12 @@ def _parse_block_nodes(
             i += 1
             continue
 
+        before = i
         node, i = _parse_paragraph(lines, i, path=f"{path}[{i}]")
-        if node.text is not None or node.children is not None:
+        if node.text or node.children is not None:
             nodes.append(node)
+        if i == before:
+            i += 1
 
     return nodes, i
 
@@ -683,7 +712,9 @@ def parse_markdown_text(
         for key in ["theme", "sheet", "meta", "styles", "defines", "$schema"]
         if key in metadata
     }
-    metadata_rest = {key: value for key, value in metadata.items() if key not in frontmatter}
+    metadata_rest = {
+        key: value for key, value in metadata.items() if key not in frontmatter
+    }
 
     lines = body.splitlines()
     slides: list[list[Node]] = [[]]
@@ -733,20 +764,12 @@ def parse_markdown_text(
 
 
 def to_canonical_ir(source: str | Path) -> Document:
-    return parse_markdown_text(
-        Path(source).read_text(encoding="utf-8") if isinstance(source, Path) else str(source),
-        path=str(source),
-    )[0]
+    text, path = _load_source_text(source)
+    return parse_markdown_text(text, path=path)[0]
 
 
 def load_markdown_document(source: str | Path) -> Document:
-    if isinstance(source, Path):
-        text = source.read_text(encoding="utf-8")
-        path = str(source)
-    else:
-        text = str(source)
-        path = "<memory>"
-
+    text, path = _load_source_text(source)
     document, _ = parse_markdown_text(text, path=path, parse_front_matter=True)
     return document
 

--- a/src/paperops/slides/dsl/mdx_parser.py
+++ b/src/paperops/slides/dsl/mdx_parser.py
@@ -1,0 +1,602 @@
+"""MDX parser that maps components and inline HTML into canonical IR nodes."""
+
+from __future__ import annotations
+
+import difflib
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from paperops.slides.components.registry import registry
+from paperops.slides.dsl.json_loader import DEFAULT_SCHEMA, Document
+from paperops.slides.dsl.markdown_parser import _parse_frontmatter
+from paperops.slides.dsl.markdown_parser import parse_markdown_fragment
+from paperops.slides.ir.schema import STYLE_KEY_SCHEMAS
+from paperops.slides.ir.node import Node
+
+
+@dataclass(frozen=True)
+class MDXParseError(ValueError):
+    """Structured parser error for MDX parsing."""
+
+    code: str
+    path: str
+    message: str
+    suggestion: list[str] | None = None
+
+    def __post_init__(self) -> None:
+        suffix = f" suggestion={self.suggestion}" if self.suggestion else ""
+        object.__setattr__(self, "args", (f"[{self.code}] {self.path}: {self.message}{suffix}",))
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = {
+            "code": self.code,
+            "path": self.path,
+            "message": self.message,
+        }
+        if self.suggestion:
+            payload["suggestion"] = list(self.suggestion)
+        return payload
+
+
+_OPEN_TAG_RE = re.compile(
+    r"^\s*<(?P<name>[A-Za-z][A-Za-z0-9_]*)(?P<attrs>(?:\s+[^\s<>/]*(?:\s*=\s*(?:\{\{.*?\}\}|\"[^\"]*\"|'[^']*'|[^\\\\s/>]+))?)*)\s*(?P<self>/)?\s*>\s*$",
+    re.DOTALL,
+)
+_SINGLE_TAG_RE = re.compile(
+    r"^\s*<(?P<name>[A-Za-z][A-Za-z0-9_]*)(?P<attrs>(?:\s+[^\s<>/]*(?:\s*=\s*(?:\{\{.*?\}\}|\"[^\"]*\"|'[^']*'|[^\\\\s/>]+))?)*)\s*>\s*(?P<body>.*?)\s*</(?P=name)\s*>\s*$",
+    re.DOTALL,
+)
+_CLOSE_TAG_RE = re.compile(r"^\s*</(?P<name>[A-Za-z][A-Za-z0-9_]*)\s*>\s*$")
+_STYLE_KEYS = set(STYLE_KEY_SCHEMAS)
+_IR_LAYOUT_TYPES = {"grid", "flex", "hstack", "stack", "vstack", "layer", "absolute", "padding"}
+
+
+def _is_component_tag(name: str) -> bool:
+    return bool(name) and name[0].isupper()
+
+
+def _coerce_js_scalar(value: str) -> Any:
+    raw = value.strip()
+    if not raw:
+        return True
+    lowered = raw.lower()
+    if lowered in {"true", "on", "yes"}:
+        return True
+    if lowered in {"false", "off", "no"}:
+        return False
+    if lowered in {"none", "null"}:
+        return None
+    if (
+        (raw.startswith("\"") and raw.endswith("\""))
+        or (raw.startswith("'") and raw.endswith("'"))
+    ):
+        return raw[1:-1]
+    if re.fullmatch(r"-?\d+", raw):
+        try:
+            return int(raw)
+        except ValueError:
+            pass
+    try:
+        return float(raw)
+    except ValueError:
+        return raw
+
+
+def _is_supported_text_component(name: str) -> bool:
+    return name in {"title", "subtitle", "heading", "text", "prose"}
+
+
+def _node_is_text_only(node: Node | str) -> bool:
+    if isinstance(node, str):
+        return True
+    if node.text is None and not node.children:
+        return False
+    if node.children is None:
+        return True
+    return all(_node_is_text_only(child) for child in node.children)
+
+
+def _flatten_node_text(node: Node | str) -> str:
+    if isinstance(node, str):
+        return node
+    text = node.text or ""
+    if node.children:
+        text += "".join(_flatten_node_text(child) for child in node.children)
+    return text
+
+
+def _build_single_line_component(
+    node_type: str,
+    props: dict[str, Any],
+    style: dict[str, Any],
+    class_name: str | None,
+    node_id: str | None,
+    body: str,
+    path: str,
+) -> Node:
+    children = parse_markdown_fragment(body, path=path)
+    if _is_supported_text_component(node_type) and children and all(
+        _node_is_text_only(child) for child in children
+    ):
+        text = "".join(_flatten_node_text(child) for child in children).strip()
+        if text:
+            return Node(
+                type=node_type,
+                class_=class_name,
+                id=node_id,
+                style=style or None,
+                text=text,
+                props=props or None,
+                children=None,
+            )
+
+    return Node(
+        type=node_type,
+        class_=class_name,
+        id=node_id,
+        style=style or None,
+        props=props or None,
+        children=children or None,
+    )
+
+
+def _tokenize_attr_tokens(raw: str) -> list[str]:
+    """Split a JSX-like attribute string into tokens."""
+
+    tokens: list[str] = []
+    i = 0
+    n = len(raw)
+    quote: str | None = None
+    brace = 0
+    bracket = 0
+    buffer: list[str] = []
+
+    while i < n:
+        ch = raw[i]
+
+        if quote is None and ch in {"'", '"'}:
+            quote = ch
+            buffer.append(ch)
+            i += 1
+            continue
+
+        if quote == ch:
+            quote = None
+            buffer.append(ch)
+            i += 1
+            continue
+
+        if quote is None and raw.startswith("{{", i):
+            brace += 1
+            buffer.append("{{")
+            i += 2
+            continue
+
+        if quote is None and raw.startswith("}}", i) and brace > 0:
+            brace -= 1
+            buffer.append("}}")
+            i += 2
+            continue
+
+        if quote is None and ch == "[":
+            bracket += 1
+            buffer.append(ch)
+            i += 1
+            continue
+
+        if quote is None and ch == "]":
+            bracket = max(bracket - 1, 0)
+            buffer.append(ch)
+            i += 1
+            continue
+
+        if (
+            quote is None
+            and brace == 0
+            and bracket == 0
+            and ch.isspace()
+        ):
+            token = "".join(buffer).strip()
+            if token:
+                tokens.append(token)
+            buffer = []
+            i += 1
+            continue
+
+        buffer.append(ch)
+        i += 1
+
+    tail = "".join(buffer).strip()
+    if tail:
+        tokens.append(tail)
+    return tokens
+
+
+def _parse_style_object(raw: str, path: str, *, at: str) -> dict[str, Any]:
+    text = raw.strip()
+    if not (text.startswith("{{") and text.endswith("}}")):
+        raise MDXParseError("INVALID_SYNTAX", path, f"Invalid JSX style object in {at}")
+
+    body = text[2:-2].strip()
+    if not body:
+        return {}
+
+    # Parse `key: value, key: value` with nested braces respected.
+    items: list[str] = []
+    token: list[str] = []
+    quote: str | None = None
+    nested = 0
+    i = 0
+
+    while i < len(body):
+        ch = body[i]
+        if quote is None and ch in {"'", '"'}:
+            quote = ch
+            token.append(ch)
+            i += 1
+            continue
+        if quote == ch:
+            quote = None
+            token.append(ch)
+            i += 1
+            continue
+        if quote is None and ch in {"{", "["}:
+            nested += 1
+            token.append(ch)
+            i += 1
+            continue
+        if quote is None and ch in {"}", "]"}:
+            nested = max(0, nested - 1)
+            token.append(ch)
+            i += 1
+            continue
+        if quote is None and ch == "," and nested == 0:
+            current = "".join(token).strip()
+            if current:
+                items.append(current)
+            token = []
+            i += 1
+            continue
+        token.append(ch)
+        i += 1
+
+    tail = "".join(token).strip()
+    if tail:
+        items.append(tail)
+
+    style: dict[str, Any] = {}
+    for item in items:
+        if ":" not in item:
+            raise MDXParseError(
+                "INVALID_SYNTAX",
+                path,
+                f"Invalid style token {item!r} in {at}",
+            )
+        raw_key, raw_value = item.split(":", 1)
+        key = raw_key.strip().strip('"').strip("'")
+        if not key:
+            continue
+        style[key] = _coerce_js_scalar(raw_value.strip())
+    return style
+
+
+def _parse_attr_value(value: str, path: str, *, at: str) -> Any:
+    if value.startswith("{{") and value.endswith("}}"):
+        return _parse_style_object(value, path, at=at)
+    if value == "{}":
+        return {}
+    return _coerce_js_scalar(value)
+
+
+def _parse_component_attrs(raw: str, path: str) -> tuple[dict[str, Any], dict[str, Any], str | None, str | None]:
+    attrs = _tokenize_attr_tokens(raw)
+    props: dict[str, Any] = {}
+    style: dict[str, Any] = {}
+    class_name: str | None = None
+    node_id: str | None = None
+
+    for raw_attr in attrs:
+        if not raw_attr:
+            continue
+        if "=" not in raw_attr:
+            props[raw_attr] = True
+            continue
+
+        key, raw_value = raw_attr.split("=", 1)
+        key = key.strip()
+        raw_value = raw_value.strip()
+        value = _parse_attr_value(raw_value, path, at=key)
+
+        if key in {"class", "className"}:
+            if isinstance(value, str):
+                class_name = value.strip()
+            continue
+        if key == "id" and isinstance(value, str):
+            node_id = value.strip()
+            continue
+
+        if key == "style":
+            if not isinstance(value, dict):
+                raise MDXParseError(
+                    "INVALID_SYNTAX",
+                    path,
+                    "<Component style=...> expects a JSX object.",
+                )
+            style.update(value)
+            continue
+
+        if key in _STYLE_KEYS:
+            style[key] = value
+            continue
+
+        props[key] = value
+
+    return props, style, class_name, node_id
+
+
+def _extract_component_open(line: str, path: str) -> tuple[str, dict[str, Any], dict[str, Any], str | None, str | None, bool] | None:
+    match = _OPEN_TAG_RE.match(line)
+    if not match:
+        return None
+
+    name = match.group("name")
+    if not name or not _is_component_tag(name):
+        return None
+
+    attrs_raw = match.group("attrs") or ""
+    is_self_closing = bool(match.group("self"))
+
+    props, style, class_name, node_id = _parse_component_attrs(attrs_raw, path)
+    lowered = name.lower()
+    if not registry.has(lowered) and lowered not in _IR_LAYOUT_TYPES:
+        suggestion = difflib.get_close_matches(
+            lowered,
+            registry.snapshot().keys(),
+            n=4,
+            cutoff=0.5,
+        )
+        suggestion_text = ", ".join(suggestion) if suggestion else "a different component name?"
+        raise MDXParseError(
+            "UNKNOWN_TYPE",
+            path,
+            f"Unknown component type '{name}'. Did you mean: {suggestion_text}?",
+            suggestion=[*suggestion] if suggestion else ["Did you mean a different component name?"],
+        )
+
+    return lowered, props, style, class_name, node_id, is_self_closing
+
+
+def _is_matching_close(line: str, expected: str) -> bool:
+    match = _CLOSE_TAG_RE.match(line)
+    return bool(match and match.group("name").lower() == expected.lower())
+
+
+def _flush_markdown_lines(lines: list[str], path: str) -> list[Node]:
+    if not lines:
+        return []
+    text = "\n".join(lines)
+    return parse_markdown_fragment(text, path=path)
+
+
+def _parse_mdx_nodes(
+    lines: list[str],
+    start: int,
+    path: str,
+    *,
+    close_tag: str | None = None,
+    allow_slide_sep: bool = False,
+) -> tuple[list[Node], int]:
+    nodes: list[Node] = []
+    i = start
+    buffer: list[str] = []
+
+    while i < len(lines):
+        line = lines[i]
+
+        if close_tag is not None and _is_matching_close(line, close_tag):
+            nodes.extend(_flush_markdown_lines(buffer, path=f"{path}[{i}]"))
+            buffer = []
+            return nodes, i + 1
+
+        if close_tag is None and allow_slide_sep and line.strip() == "---":
+            nodes.extend(_flush_markdown_lines(buffer, path=f"{path}[{i}]"))
+            buffer = []
+            return nodes, i
+
+        single_line_match = _SINGLE_TAG_RE.match(line)
+        if single_line_match is not None:
+            single_line_name = single_line_match.group("name")
+            if _is_component_tag(single_line_name):
+                single_line_attrs = single_line_match.group("attrs") or ""
+                single_line_body = (single_line_match.group("body") or "").strip()
+                props, style, class_name, node_id = _parse_component_attrs(
+                    single_line_attrs,
+                    path=f"{path}[{i}]",
+                )
+                single_line_type = single_line_name.lower()
+                if (
+                    not registry.has(single_line_type)
+                    and single_line_type not in _IR_LAYOUT_TYPES
+                ):
+                    suggestion = difflib.get_close_matches(
+                        single_line_type,
+                        registry.snapshot().keys(),
+                        n=4,
+                        cutoff=0.5,
+                    )
+                    suggestion_text = ", ".join(suggestion) if suggestion else "a different component name?"
+                    raise MDXParseError(
+                        "UNKNOWN_TYPE",
+                        f"{path}[{i}]",
+                        f"Unknown component type '{single_line_name}'. Did you mean: {suggestion_text}?",
+                        suggestion=[*suggestion] if suggestion else ["Did you mean a different component name?"],
+                    )
+                nodes.extend(_flush_markdown_lines(buffer, path=f"{path}[{i}]"))
+                buffer = []
+                nodes.append(
+                    _build_single_line_component(
+                        single_line_type,
+                        props,
+                        style,
+                        class_name,
+                        node_id,
+                        single_line_body,
+                        path=f"{path}[{i}]",
+                    )
+                )
+                i += 1
+                continue
+
+        parsed = _extract_component_open(line, path=f"{path}[{i}]")
+        if parsed is not None:
+            node_type, props, style, class_name, node_id, is_self_closing = parsed
+            nodes.extend(_flush_markdown_lines(buffer, path=f"{path}[{i}]"))
+            buffer = []
+
+            if is_self_closing:
+                nodes.append(
+                    Node(
+                        type=node_type,
+                        class_=class_name,
+                        id=node_id,
+                        style=style or None,
+                        props=props,
+                        children=None,
+                    ),
+                )
+                i += 1
+                continue
+
+            child_nodes, i = _parse_mdx_nodes(
+                lines,
+                i + 1,
+                path=path,
+                close_tag=node_type,
+                allow_slide_sep=False,
+            )
+            nodes.append(
+                Node(
+                    type=node_type,
+                    class_=class_name,
+                    id=node_id,
+                    style=style or None,
+                    props=props,
+                    children=child_nodes or None,
+                ),
+            )
+            continue
+
+        buffer.append(line)
+        i += 1
+
+    if close_tag is not None:
+        raise MDXParseError("INVALID_SYNTAX", path, f"Unclosed component <{close_tag}>")
+
+    nodes.extend(_flush_markdown_lines(buffer, path=f"{path}[{i}]"))
+    return nodes, i
+
+
+def parse_mdx_fragment(source: str, *, path: str = "mdx") -> list[Node]:
+    nodes, _ = _parse_mdx_nodes(
+        source.splitlines(),
+        0,
+        path=path,
+        close_tag=None,
+        allow_slide_sep=False,
+    )
+    return nodes
+
+
+def parse_mdx_text(
+    source: str,
+    *,
+    path: str = "mdx",
+) -> tuple[Document, dict[str, Any]]:
+    metadata, body = _parse_frontmatter(source)
+
+    frontmatter = {
+        key: metadata[key]
+        for key in ["theme", "sheet", "meta", "styles", "defines", "$schema"]
+        if key in metadata
+    }
+    metadata_rest = {
+        key: value for key, value in metadata.items() if key not in frontmatter
+    }
+
+    lines = body.splitlines()
+    slides: list[list[Node]] = [[]]
+    i = 0
+    while i < len(lines):
+        raw_line = lines[i]
+        if raw_line.strip() == "---":
+            if slides and slides[-1] != []:
+                slides.append([])
+            else:
+                slides.append([])
+            i += 1
+            continue
+
+        chunk_nodes, i = _parse_mdx_nodes(
+            lines,
+            i,
+            path=path,
+            close_tag=None,
+            allow_slide_sep=True,
+        )
+        if chunk_nodes:
+            slides[-1].extend(chunk_nodes)
+    while slides and slides[-1] == [] and len(slides) > 1:
+        slides.pop()
+
+    if not slides:
+        slides = [[]]
+
+    payload: dict[str, Any] = {
+        "$schema": frontmatter.get("$schema", DEFAULT_SCHEMA),
+        "theme": frontmatter.get("theme", "minimal"),
+        "slides": [
+            {"type": "slide", "children": [node.to_dict() for node in nodes]}
+            for nodes in slides
+        ],
+    }
+
+    if "sheet" in frontmatter:
+        payload["sheet"] = frontmatter["sheet"]
+    if "styles" in frontmatter:
+        payload["styles"] = frontmatter["styles"]
+    if "defines" in frontmatter:
+        payload["defines"] = frontmatter["defines"]
+    if "meta" in frontmatter:
+        payload["meta"] = frontmatter["meta"]
+
+    return Document.from_dict(payload), metadata_rest
+
+
+def to_canonical_ir(source: str | Path) -> Document:
+    return parse_mdx_text(
+        Path(source).read_text(encoding="utf-8") if isinstance(source, Path) else str(source),
+        path=str(source),
+    )[0]
+
+
+def load_mdx_document(source: str | Path) -> Document:
+    if isinstance(source, Path):
+        text = source.read_text(encoding="utf-8")
+        path = str(source)
+    else:
+        text = str(source)
+        path = "<memory>"
+
+    document, _ = parse_mdx_text(text, path=path)
+    return document
+
+
+__all__ = [
+    "MDXParseError",
+    "load_mdx_document",
+    "parse_mdx_fragment",
+    "parse_mdx_text",
+    "to_canonical_ir",
+]

--- a/src/paperops/slides/dsl/mdx_parser.py
+++ b/src/paperops/slides/dsl/mdx_parser.py
@@ -10,13 +10,16 @@ from typing import Any
 
 from paperops.slides.components.registry import registry
 from paperops.slides.dsl.json_loader import DEFAULT_SCHEMA, Document
-from paperops.slides.dsl.markdown_parser import _parse_frontmatter
-from paperops.slides.dsl.markdown_parser import parse_markdown_fragment
-from paperops.slides.ir.schema import STYLE_KEY_SCHEMAS
+from paperops.slides.dsl.markdown_parser import (
+    _load_source_text,
+    _parse_frontmatter,
+    parse_markdown_fragment,
+)
 from paperops.slides.ir.node import Node
+from paperops.slides.ir.schema import STYLE_KEY_SCHEMAS
 
 
-@dataclass(frozen=True)
+@dataclass
 class MDXParseError(ValueError):
     """Structured parser error for MDX parsing."""
 
@@ -27,7 +30,7 @@ class MDXParseError(ValueError):
 
     def __post_init__(self) -> None:
         suffix = f" suggestion={self.suggestion}" if self.suggestion else ""
-        object.__setattr__(self, "args", (f"[{self.code}] {self.path}: {self.message}{suffix}",))
+        self.args = (f"[{self.code}] {self.path}: {self.message}{suffix}",)
 
     def to_dict(self) -> dict[str, Any]:
         payload = {
@@ -50,7 +53,16 @@ _SINGLE_TAG_RE = re.compile(
 )
 _CLOSE_TAG_RE = re.compile(r"^\s*</(?P<name>[A-Za-z][A-Za-z0-9_]*)\s*>\s*$")
 _STYLE_KEYS = set(STYLE_KEY_SCHEMAS)
-_IR_LAYOUT_TYPES = {"grid", "flex", "hstack", "stack", "vstack", "layer", "absolute", "padding"}
+_IR_LAYOUT_TYPES = {
+    "grid",
+    "flex",
+    "hstack",
+    "stack",
+    "vstack",
+    "layer",
+    "absolute",
+    "padding",
+}
 
 
 def _is_component_tag(name: str) -> bool:
@@ -68,9 +80,8 @@ def _coerce_js_scalar(value: str) -> Any:
         return False
     if lowered in {"none", "null"}:
         return None
-    if (
-        (raw.startswith("\"") and raw.endswith("\""))
-        or (raw.startswith("'") and raw.endswith("'"))
+    if (raw.startswith('"') and raw.endswith('"')) or (
+        raw.startswith("'") and raw.endswith("'")
     ):
         return raw[1:-1]
     if re.fullmatch(r"-?\d+", raw):
@@ -117,8 +128,10 @@ def _build_single_line_component(
     path: str,
 ) -> Node:
     children = parse_markdown_fragment(body, path=path)
-    if _is_supported_text_component(node_type) and children and all(
-        _node_is_text_only(child) for child in children
+    if (
+        _is_supported_text_component(node_type)
+        and children
+        and all(_node_is_text_only(child) for child in children)
     ):
         text = "".join(_flatten_node_text(child) for child in children).strip()
         if text:
@@ -192,12 +205,7 @@ def _tokenize_attr_tokens(raw: str) -> list[str]:
             i += 1
             continue
 
-        if (
-            quote is None
-            and brace == 0
-            and bracket == 0
-            and ch.isspace()
-        ):
+        if quote is None and brace == 0 and bracket == 0 and ch.isspace():
             token = "".join(buffer).strip()
             if token:
                 tokens.append(token)
@@ -290,7 +298,9 @@ def _parse_attr_value(value: str, path: str, *, at: str) -> Any:
     return _coerce_js_scalar(value)
 
 
-def _parse_component_attrs(raw: str, path: str) -> tuple[dict[str, Any], dict[str, Any], str | None, str | None]:
+def _parse_component_attrs(
+    raw: str, path: str
+) -> tuple[dict[str, Any], dict[str, Any], str | None, str | None]:
     attrs = _tokenize_attr_tokens(raw)
     props: dict[str, Any] = {}
     style: dict[str, Any] = {}
@@ -336,7 +346,9 @@ def _parse_component_attrs(raw: str, path: str) -> tuple[dict[str, Any], dict[st
     return props, style, class_name, node_id
 
 
-def _extract_component_open(line: str, path: str) -> tuple[str, dict[str, Any], dict[str, Any], str | None, str | None, bool] | None:
+def _extract_component_open(
+    line: str, path: str
+) -> tuple[str, dict[str, Any], dict[str, Any], str | None, str | None, bool] | None:
     match = _OPEN_TAG_RE.match(line)
     if not match:
         return None
@@ -357,12 +369,18 @@ def _extract_component_open(line: str, path: str) -> tuple[str, dict[str, Any], 
             n=4,
             cutoff=0.5,
         )
-        suggestion_text = ", ".join(suggestion) if suggestion else "a different component name?"
+        suggestion_text = (
+            ", ".join(suggestion) if suggestion else "a different component name?"
+        )
         raise MDXParseError(
             "UNKNOWN_TYPE",
             path,
             f"Unknown component type '{name}'. Did you mean: {suggestion_text}?",
-            suggestion=[*suggestion] if suggestion else ["Did you mean a different component name?"],
+            suggestion=(
+                [*suggestion]
+                if suggestion
+                else ["Did you mean a different component name?"]
+            ),
         )
 
     return lowered, props, style, class_name, node_id, is_self_closing
@@ -426,12 +444,20 @@ def _parse_mdx_nodes(
                         n=4,
                         cutoff=0.5,
                     )
-                    suggestion_text = ", ".join(suggestion) if suggestion else "a different component name?"
+                    suggestion_text = (
+                        ", ".join(suggestion)
+                        if suggestion
+                        else "a different component name?"
+                    )
                     raise MDXParseError(
                         "UNKNOWN_TYPE",
                         f"{path}[{i}]",
                         f"Unknown component type '{single_line_name}'. Did you mean: {suggestion_text}?",
-                        suggestion=[*suggestion] if suggestion else ["Did you mean a different component name?"],
+                        suggestion=(
+                            [*suggestion]
+                            if suggestion
+                            else ["Did you mean a different component name?"]
+                        ),
                     )
                 nodes.extend(_flush_markdown_lines(buffer, path=f"{path}[{i}]"))
                 buffer = []
@@ -462,7 +488,7 @@ def _parse_mdx_nodes(
                         class_=class_name,
                         id=node_id,
                         style=style or None,
-                        props=props,
+                        props=props or None,
                         children=None,
                     ),
                 )
@@ -482,7 +508,7 @@ def _parse_mdx_nodes(
                     class_=class_name,
                     id=node_id,
                     style=style or None,
-                    props=props,
+                    props=props or None,
                     children=child_nodes or None,
                 ),
             )
@@ -575,20 +601,12 @@ def parse_mdx_text(
 
 
 def to_canonical_ir(source: str | Path) -> Document:
-    return parse_mdx_text(
-        Path(source).read_text(encoding="utf-8") if isinstance(source, Path) else str(source),
-        path=str(source),
-    )[0]
+    text, path = _load_source_text(source, fallback_path="mdx")
+    return parse_mdx_text(text, path=path)[0]
 
 
 def load_mdx_document(source: str | Path) -> Document:
-    if isinstance(source, Path):
-        text = source.read_text(encoding="utf-8")
-        path = str(source)
-    else:
-        text = str(source)
-        path = "<memory>"
-
+    text, path = _load_source_text(source, fallback_path="mdx")
     document, _ = parse_mdx_text(text, path=path)
     return document
 

--- a/src/paperops/slides/layout/engine.py
+++ b/src/paperops/slides/layout/engine.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from paperops.slides.core.constants import CONTENT_REGION, Region, SLIDE_HEIGHT, SLIDE_WIDTH
+from paperops.slides.dsl.inline_html import run_style_overrides
 from paperops.slides.ir.node import Node
 from paperops.slides.components.table import Table as LayoutTable
 from paperops.slides.components.text import TextBlock
@@ -188,6 +189,100 @@ def _extract_node_text(node: Node) -> str:
     return "".join(chunks)
 
 
+def _inline_style_to_run_style(style: dict[str, Any]) -> dict[str, Any]:
+    run: dict[str, Any] = {}
+
+    if "color" in style:
+        run["color"] = style["color"]
+    if "background_color" in style:
+        run["background_color"] = style["background_color"]
+    if "background-color" in style:
+        run["background_color"] = style["background-color"]
+
+    if "font_weight" in style:
+        weight = style["font_weight"]
+        if isinstance(weight, (int, float)):
+            run["bold"] = float(weight) >= 600.0
+        elif isinstance(weight, str) and weight:
+            run["bold"] = weight.lower() in {"bold", "bolder", "600", "700", "800", "900"}
+    if "font-weight" in style:
+        weight = style["font-weight"]
+        if isinstance(weight, (int, float)):
+            run["bold"] = float(weight) >= 600.0
+        elif isinstance(weight, str) and weight:
+            run["bold"] = weight.lower() in {"bold", "bolder", "600", "700", "800", "900"}
+    if "font_style" in style:
+        run["italic"] = str(style["font_style"]).lower() == "italic"
+    if "font-style" in style:
+        run["italic"] = str(style["font-style"]).lower() == "italic"
+
+    if "font_family" in style:
+        run["font_family"] = style["font_family"]
+    if "font-family" in style:
+        run["font_family"] = style["font-family"]
+    if "vertAlign" in style:
+        run["vertAlign"] = style["vertAlign"]
+    if "vert-align" in style:
+        run["vertAlign"] = style["vert-align"]
+    if "href" in style:
+        run["href"] = style["href"]
+    if "bold" in style:
+        run["bold"] = style["bold"]
+    if "italic" in style:
+        run["italic"] = style["italic"]
+    if "underline" in style:
+        run["underline"] = style["underline"]
+    if "strike" in style:
+        run["strike"] = style["strike"]
+    if "text_decoration" in style:
+        deco = str(style["text_decoration"]).lower()
+        if "underline" in deco:
+            run["underline"] = True
+        if "line-through" in deco or "strike" in deco:
+            run["strike"] = True
+    if "text-decoration" in style:
+        deco = str(style["text-decoration"]).lower()
+        if "underline" in deco:
+            run["underline"] = True
+        if "line-through" in deco or "strike" in deco:
+            run["strike"] = True
+    if "highlight" in style:
+        run["highlight"] = style["highlight"]
+
+    return run
+
+
+def _merge_style(base: dict[str, Any], overrides: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(base)
+    merged.update(overrides)
+    return merged
+
+
+def _node_rich_text_runs(nodes: list[str | Node], inherited: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+    runs: list[tuple[str, dict[str, Any]]] = []
+    for child in nodes:
+        if isinstance(child, str):
+            runs.append((child, dict(inherited)))
+            continue
+        if not isinstance(child, Node):
+            continue
+
+        child_style = _merge_style(inherited, _inline_style_to_run_style(run_style_overrides(child.type, child.props or {})))
+
+        if child.type == "br":
+            runs.append(("\n", dict(inherited)))
+            continue
+
+        if child.children:
+            runs.extend(_node_rich_text_runs(child.children, child_style))
+            continue
+
+        if child.text:
+            runs.append((child.text, dict(child_style)))
+
+    return runs
+
+
 def _build_style_font_size(style: dict[str, Any], theme) -> float:
     value = style.get("font")
     if value is None:
@@ -209,6 +304,12 @@ def _build_layout_leaf(node: Node, theme) -> LayoutNode:
     text = _extract_node_text(node)
     node_type = node.type
     props = dict(node.props or {})
+    base_run_style = _inline_style_to_run_style(style)
+    runs = _node_rich_text_runs(node.children, base_run_style) if node.children else None
+    if runs is not None and not runs:
+        runs = None
+    if runs:
+        text = "".join(part for part, _ in runs)
 
     if node_type in {"box", "kpi"}:
         props = dict(node.props or {})
@@ -276,6 +377,7 @@ def _build_layout_leaf(node: Node, theme) -> LayoutNode:
             line_spacing=float(style.get("line-height", 1.25)),
             margin_x=float(style.get("padding-left", 0.0) or 0.0),
             margin_y=float(style.get("padding-top", 0.0) or 0.0),
+            runs=runs,
         )
         _apply_style_to_layout_node(layout, node)
         _attach_source(layout, node)
@@ -351,6 +453,7 @@ def _build_layout_leaf(node: Node, theme) -> LayoutNode:
         line_spacing=float(style.get("line-height", 1.25)),
         margin_x=float(style.get("padding-left", 0.0) or 0.0),
         margin_y=float(style.get("padding-top", 0.0) or 0.0),
+        runs=runs,
     )
     _apply_style_to_layout_node(layout, node)
     _attach_source(layout, node)

--- a/tests/dsl/test_markdown_mdx_parsers.py
+++ b/tests/dsl/test_markdown_mdx_parsers.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import importlib.util
+from importlib.machinery import ModuleSpec
+from pathlib import Path
+
+import pytest
+
+from paperops.slides.dsl.inline_html import InlineHtmlError
+from paperops.slides.dsl.json_loader import load_json_document
+from paperops.slides.dsl.markdown_parser import (
+    load_markdown_document,
+    parse_markdown_fragment,
+    parse_markdown_text,
+)
+from paperops.slides.dsl.markdown_parser import (
+    to_canonical_ir as markdown_to_canonical_ir,
+)
+from paperops.slides.dsl.mdx_parser import (
+    MDXParseError,
+    load_mdx_document,
+    parse_mdx_text,
+)
+from paperops.slides.dsl.mdx_parser import to_canonical_ir as mdx_to_canonical_ir
+
+FIXTURE_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "issue5"
+
+
+def _load_python_fixture() -> dict:
+    path = FIXTURE_DIR / "gallery.py"
+    spec: ModuleSpec = importlib.util.spec_from_file_location("issue5_gallery_py", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.DECK.to_dict()
+
+
+def test_gallery_four_frontends_emit_same_canonical_ir():
+    json_doc = load_json_document(FIXTURE_DIR / "gallery.json").to_dict()
+
+    markdown_doc = load_markdown_document(FIXTURE_DIR / "gallery.md").to_dict()
+    assert markdown_doc == json_doc
+
+    mdx_doc = load_mdx_document(FIXTURE_DIR / "gallery.mdx").to_dict()
+    assert mdx_doc == json_doc
+
+    python_doc = _load_python_fixture()
+    assert python_doc == json_doc
+
+
+def test_markdown_frontmatter_and_fenced_blocks_with_attributes_and_slide_separator():
+    source = """---\ntheme: minimal\nsheet: seminar\nmeta:\n  title: Gallery\n  author: PaperOps\nstyles:\n  .cover:\n    bg: bg_alt\ndefines:\n  KPI:\n    type: card\n    class: kpi\n---\n# Title {.cover #hero}\n\n> Subtitle\n{.subtitle}\n\n::: grid {cols=\"1fr 1fr\" gap=\"md\"}\n::: card.kpi\n**DAU** 125k\n:::\n::: card.kpi\n**Retention** 42%\n:::\n::::\n---\n## Outro\n"""
+
+    document = parse_markdown_text(source)[0]
+    assert document.theme == "minimal"
+    assert document.sheet == "seminar"
+    assert document.meta == {"title": "Gallery", "author": "PaperOps"}
+    assert document.styles == {".cover": {"bg": "bg_alt"}}
+    assert document.defines == {"KPI": {"type": "card", "class": "kpi"}}
+    assert len(document.slides) == 2
+    assert document.slides[0].children[0].type == "title"
+    assert document.slides[0].children[0].class_ == "cover"
+    assert document.slides[0].children[0].id == "hero"
+    assert document.slides[0].children[1].type == "prose"
+    assert document.slides[0].children[1].class_ == "subtitle"
+    assert document.slides[0].children[2].type == "grid"
+    assert document.slides[0].children[2].style == {"cols": "1fr 1fr", "gap": "md"}
+    assert len(document.slides[0].children[2].children or []) == 2
+    assert len(document.slides[1].children) == 1
+    assert document.slides[1].children[0].type == "heading"
+
+
+def test_markdown_paragraph_attribute_and_quote_line():
+    doc = parse_markdown_text("> Subtitle here.\n{.subtitle}")[0]
+    assert len(doc.slides) == 1
+    title = doc.slides[0].children[0]
+    assert title.type == "prose"
+    assert title.class_ == "subtitle"
+
+
+def test_markdown_fenced_div_parsing_preserves_nested_blocks():
+    text = """::: grid {cols=\"1fr 1fr\" gap=\"md\"}
+::: card.kpi
+A
+:::
+::: card.kpi
+B
+:::
+::::
+"""
+    nodes = parse_markdown_fragment(text)
+    assert len(nodes) == 1
+    assert nodes[0].type == "grid"
+    assert nodes[0].style == {"cols": "1fr 1fr", "gap": "md"}
+    assert len(nodes[0].children or []) == 2
+
+
+def test_markdown_inline_escape_less_than_with_space_or_digit_is_literal():
+    nodes = parse_markdown_fragment("Use < 3 and 4 < 5")
+    assert nodes[0].text == "Use < 3 and 4 < 5"
+
+
+def test_markdown_span_style_color_parsed_and_invalid_display_blocked():
+    good = parse_markdown_fragment('<span style="color:#ff0000">red</span>')[0]
+    assert good.children and good.children[0].type == "span"
+    assert good.children[0].props == {"style": {"color": "#ff0000"}}
+
+    with pytest.raises(InlineHtmlError) as exc_info:
+        parse_markdown_fragment('<span style="display:flex">bad</span>')
+    assert exc_info.value.code == "UNSUPPORTED_INLINE_HTML"
+    assert exc_info.value.suggestion is not None
+
+
+def test_markdown_unsupported_inline_html_reports_diagnostic():
+    with pytest.raises(InlineHtmlError) as exc_info:
+        parse_markdown_fragment("hello <div>bad</div> world")
+    assert exc_info.value.code == "UNSUPPORTED_INLINE_HTML"
+    assert "fenced div" in " ".join(exc_info.value.suggestion or []).lower()
+
+
+def test_mdx_component_properties_style_and_unknown_component_error():
+    source = """<KPI label=\"DAU\" value=\"125k\" />\n<Grid cols=\"1fr 1fr\" gap=\"lg\">\n</Grid>"""
+    document = parse_mdx_text(source)[0]
+    kpi, grid = document.slides[0].children
+    assert kpi.type == "kpi"
+    assert kpi.props == {"label": "DAU", "value": "125k"}
+    assert grid.type == "grid"
+    assert grid.style == {"cols": "1fr 1fr", "gap": "lg"}
+    assert not grid.props
+
+    with pytest.raises(MDXParseError) as exc_info:
+        parse_mdx_text("<UnknownTag />")
+    assert exc_info.value.code == "UNKNOWN_TYPE"
+    assert exc_info.value.suggestion is not None
+
+
+def test_mdx_style_object_and_markdown_children_are_parsed():
+    source = """<Card>\n\n- one\n- two\n</Card>\n\n<Grid style={{ cols: \"1fr 1fr\", gap: \"md\" }}>\n  <Heading>Cell A</Heading>\n  <Heading>Cell B</Heading>\n</Grid>"""
+    document = parse_mdx_text(source)[0]
+    card = document.slides[0].children[0]
+    grid = document.slides[0].children[1]
+    assert card.type == "card"
+    assert card.children and card.children[0].type == "list"
+    assert grid.type == "grid"
+    assert grid.style == {"cols": "1fr 1fr", "gap": "md"}
+    assert len(grid.children or []) == 2
+    assert (grid.children or [])[0].type == "heading"
+
+
+def test_to_canonical_ir_handles_files_by_path_string_for_markdown_and_mdx():
+    markdown_path = str(FIXTURE_DIR / "gallery.md")
+    mdx_path = str(FIXTURE_DIR / "gallery.mdx")
+
+    assert (
+        markdown_to_canonical_ir(markdown_path).to_dict()
+        == parse_markdown_text(Path(markdown_path).read_text(encoding="utf-8"))[
+            0
+        ].to_dict()
+    )
+    assert (
+        mdx_to_canonical_ir(mdx_path).to_dict()
+        == parse_mdx_text(Path(mdx_path).read_text(encoding="utf-8"))[0].to_dict()
+    )

--- a/tests/fixtures/issue5/gallery.json
+++ b/tests/fixtures/issue5/gallery.json
@@ -1,0 +1,35 @@
+{
+  "theme": "minimal",
+  "slides": [
+    {
+      "type": "slide",
+      "children": [
+        {
+          "type": "title",
+          "text": "Gallery"
+        },
+        {
+          "type": "heading",
+          "text": "Overview"
+        },
+        {
+          "type": "grid",
+          "style": {
+            "cols": "1fr 1fr",
+            "gap": "md"
+          },
+          "children": [
+            {
+              "type": "heading",
+              "text": "Cell A"
+            },
+            {
+              "type": "heading",
+              "text": "Cell B"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/issue5/gallery.md
+++ b/tests/fixtures/issue5/gallery.md
@@ -1,0 +1,8 @@
+# Gallery
+
+## Overview
+
+::: grid {cols="1fr 1fr" gap="md"}
+## Cell A
+## Cell B
+:::

--- a/tests/fixtures/issue5/gallery.mdx
+++ b/tests/fixtures/issue5/gallery.mdx
@@ -1,0 +1,12 @@
+---
+theme: minimal
+---
+
+# Gallery
+
+## Overview
+
+<Grid cols="1fr 1fr" gap="md">
+<Heading>Cell A</Heading>
+<Heading>Cell B</Heading>
+</Grid>

--- a/tests/fixtures/issue5/gallery.py
+++ b/tests/fixtures/issue5/gallery.py
@@ -1,0 +1,12 @@
+from paperops.slides.dsl import Deck, Grid, Heading, Title
+
+
+DECK = Deck(theme="minimal")
+DECK.slide(
+    Title("Gallery"),
+    Heading("Overview"),
+    Grid(style={"cols": "1fr 1fr", "gap": "md"})[
+        Heading("Cell A"),
+        Heading("Cell B"),
+    ],
+)


### PR DESCRIPTION
## Summary

Adds three authoring frontends that compile to the same canonical IR as JSON and Python builders:

- **Markdown parser** — frontmatter + ATX heading attributes + fenced div nesting + paragraph attribute + slide separator
- **Inline HTML allowlist** — `<b> <strong> <i> <em> <u> <s> <del> <sub> <sup> <br> <code> <a> <span> <mark>` only; `<span style="color:...">` allowed for color/background-color/font-weight/font-style/text-decoration; everything else raises `UNSUPPORTED_INLINE_HTML` with replacement suggestions
- **MDX parser** — capitalized tags resolved against the component registry, `style={{...}}` JSX object form, attribute fallback into `style`, CommonMark inside component children, unknown components produce `UNKNOWN_TYPE` with did-you-mean

## Acceptance Criteria

- [x] Four-frontend gallery: `gallery.json`, `gallery.py`, `gallery.mdx`, `gallery.md` produce identical canonical IR (`tests/dsl/test_markdown_mdx_parsers.py::test_gallery_four_frontends_emit_same_canonical_ir`)
- [x] `<div>` in Markdown/MDX → `UNSUPPORTED_INLINE_HTML` + suggestion
- [x] `<span style="display:flex">` → error (display not in allowlist)
- [x] `<span style="color:#ff0000">red</span>` → red text run
- [x] `<KPI label="DAU" value="125k" />` → IR with `type=kpi`, props `{label, value}`
- [x] Unknown capitalized MDX tag → `UNKNOWN_TYPE` with did-you-mean suggestion
- [x] Markdown `<` followed by space/digit → preserved as literal

## Validation

- `uv run pytest -q` → **82 passed**
- DSL tests: 10/10 (gallery roundtrip + fenced div + frontmatter + slide separator + inline HTML allowlist + MDX components + MDX style object + unknown type errors)

Closes #5.